### PR TITLE
Fix Drop Helper appearing in Alt+Tab

### DIFF
--- a/RHI.DropHelper/Program.cs
+++ b/RHI.DropHelper/Program.cs
@@ -37,6 +37,18 @@ static class Program
 
 class DropOverlayForm : Form
 {
+    private const int WS_EX_TOOLWINDOW = 0x00000080;
+
+    protected override CreateParams CreateParams
+    {
+        get
+        {
+            var createParams = base.CreateParams;
+            createParams.ExStyle |= WS_EX_TOOLWINDOW;
+            return createParams;
+        }
+    }
+
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     private static extern IntPtr FindWindow(string? cls, string title);
 

--- a/RHI.DropHelper/RHI.DropHelper.csproj
+++ b/RHI.DropHelper/RHI.DropHelper.csproj
@@ -8,4 +8,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>RHI.DropHelper</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="RenoDXCommander.Tests" />
+  </ItemGroup>
 </Project>

--- a/RenoDXCommander.Tests/DropOverlayFormTests.cs
+++ b/RenoDXCommander.Tests/DropOverlayFormTests.cs
@@ -1,0 +1,44 @@
+using System.Runtime.ExceptionServices;
+using RHI.DropHelper;
+using Xunit;
+
+namespace RenoDXCommander.Tests;
+
+public class DropOverlayFormTests
+{
+    private const int WsExToolWindow = 0x00000080;
+
+    [Fact]
+    public void CreateParams_MarksOverlayAsToolWindow()
+    {
+        Exception? error = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                using var form = new TestableDropOverlayForm();
+                Assert.Equal(WsExToolWindow, form.ExtendedStyle & WsExToolWindow);
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (error is not null)
+            ExceptionDispatchInfo.Capture(error).Throw();
+    }
+
+    private sealed class TestableDropOverlayForm : DropOverlayForm
+    {
+        public TestableDropOverlayForm()
+            : base(IntPtr.Zero, Path.GetTempPath())
+        {
+        }
+
+        public int ExtendedStyle => CreateParams.ExStyle;
+    }
+}

--- a/RenoDXCommander.Tests/RenoDXCommander.Tests.csproj
+++ b/RenoDXCommander.Tests/RenoDXCommander.Tests.csproj
@@ -13,6 +13,7 @@
     <WindowsPackageType>None</WindowsPackageType>
     <EnableMsixTooling>false</EnableMsixTooling>
     <UseWinUI>true</UseWinUI>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RenoDXCommander\RenoDXCommander.csproj" />
+    <ProjectReference Include="..\RHI.DropHelper\RHI.DropHelper.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- mark the transparent drop-helper overlay as a Win32 tool window
- keep Discord/browser drag-and-drop available while excluding the helper from Alt+Tab
- add a regression test for the overlay's extended window style

## Root cause

`ShowInTaskbar = false` kept the borderless helper off the taskbar, but its live extended style did not include `WS_EX_TOOLWINDOW`. Windows therefore still treated the visible overlay as an Alt+Tab candidate.

The fix adds `WS_EX_TOOLWINDOW` through the form's `CreateParams`, so the style is present when Windows creates or recreates the helper window.

## Verification

- Before the fix, the new regression test failed with `Expected: 128`, `Actual: 0`.
- `dotnet test RenoDXCommander.Tests/RenoDXCommander.Tests.csproj -c Release --filter FullyQualifiedName~DropOverlayFormTests` — 1 passed
- `dotnet test RenoDXCommander.sln -c Release -p:Platform=x64 --no-restore` — 33 passed
- A rebuilt helper launched on Windows 11 with extended style `0x90080` (`WS_EX_TOOLWINDOW` set), instead of the previous `0x90000`.

## Risk

Low. The change affects only window-switcher classification; the overlay remains visible to drag-and-drop and retains its existing positioning, opacity, and activation behavior.
