### PR TITLE
Add multilingual UI support with Simplified Chinese

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ RenoDXCommander.Tests/bin
 RenoDXCommander.Tests/obj
 RHI.DropHelper/bin
 RHI.DropHelper/obj
+publish/
+installers/
 publish.bat
 OPTI/
 downloads_tidyup.md

--- a/Installer/Languages/ChineseSimplified.isl
+++ b/Installer/Languages/ChineseSimplified.isl
@@ -1,0 +1,417 @@
+; *** Inno Setup version 6.5.0+ Chinese Simplified messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintainer: Zhenghan Yang (Kira)
+; Email: 847320916@QQ.com
+; Github: https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+; Encoding: UTF-8
+; Translation based on network resource
+;
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=简体中文
+; About LanguageID, to reference link:
+; https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
+LanguageID=$0804
+; LanguageCodePage should always be set if possible, even if this file is Unicode
+; For English it's set to zero anyway because English only uses ASCII characters
+LanguageCodePage=936
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=9
+;DialogFontBaseScaleWidth=7
+;DialogFontBaseScaleHeight=15
+;WelcomeFontName=Segoe UI
+;WelcomeFontSize=14
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=安装
+SetupWindowTitle=安装 - %1
+UninstallAppTitle=卸载
+UninstallAppFullTitle=%1 卸载
+
+; *** Misc. common
+InformationTitle=信息
+ConfirmTitle=确认
+ErrorTitle=错误
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=现在将安装 %1。您想要继续吗？
+LdrCannotCreateTemp=无法创建临时文件。安装程序已中止
+LdrCannotExecTemp=无法执行临时目录中的文件。安装程序已中止
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1。%n%n错误 %2: %3
+SetupFileMissing=安装目录中缺少文件 %1。请修正这个问题或者获取程序的新副本。
+SetupFileCorrupt=安装文件已损坏。请获取程序的新副本。
+SetupFileCorruptOrWrongVer=安装文件已损坏，或是与这个安装程序的版本不兼容。请修正这个问题或获取新的程序副本。
+InvalidParameter=无效的命令行参数：%n%n%1
+SetupAlreadyRunning=安装程序已在运行。
+WindowsVersionNotSupported=此程序不支持当前计算机运行的 Windows 版本。
+WindowsServicePackRequired=此程序需要 %1 服务包 %2 或更高版本。
+NotOnThisPlatform=此程序不能在 %1 上运行。
+OnlyOnThisPlatform=此程序只能在 %1 上运行。
+OnlyOnTheseArchitectures=此程序只能安装到为下列处理器架构设计的 Windows 版本中：%n%n%1
+WinVersionTooLowError=此程序需要 %1 版本 %2 或更高。
+WinVersionTooHighError=此程序不能安装于 %1 版本 %2 或更高。
+AdminPrivilegesRequired=在安装此程序时您必须以管理员身份登录。
+PowerUserPrivilegesRequired=在安装此程序时您必须以管理员身份或高级用户组身份登录。
+SetupAppRunningError=安装程序检测到 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+UninstallAppRunningError=卸载程序检测到 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=选择安装程序安装模式
+PrivilegesRequiredOverrideInstruction=选择安装模式
+PrivilegesRequiredOverrideText1=%1 可以为所有用户安装（需要管理员权限），或仅为您安装。
+PrivilegesRequiredOverrideText2=%1 可以仅为您安装，或为所有用户安装（需要管理员权限）。
+PrivilegesRequiredOverrideAllUsers=为所有用户安装(&A)
+PrivilegesRequiredOverrideAllUsersRecommended=为所有用户安装(&A)（推荐）
+PrivilegesRequiredOverrideCurrentUser=仅为我安装(&M)
+PrivilegesRequiredOverrideCurrentUserRecommended=仅为我安装(&M)（推荐）
+
+; *** Misc. errors
+ErrorCreatingDir=安装程序无法创建目录“%1”
+ErrorTooManyFilesInDir=无法在目录“%1”中创建文件，因为里面包含太多文件。
+
+; *** Setup common messages
+ExitSetupTitle=退出安装程序
+ExitSetupMessage=安装程序尚未完成。如果现在退出，将不会安装该程序。%n%n您之后可以再次运行安装程序完成安装。%n%n现在退出安装程序吗？
+AboutSetupMenuItem=关于安装程序(&A)...
+AboutSetupTitle=关于安装程序
+AboutSetupMessage=%1 版本 %2%n%3%n%n%1 主页：%n%4
+AboutSetupNote=
+TranslatorNote=简体中文翻译由 Kira（847320916@qq.com）维护。项目地址：https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+
+; *** Buttons
+ButtonBack=< 上一步(&B)
+ButtonNext=下一步(&N) >
+ButtonInstall=安装(&I)
+ButtonOK=确定
+ButtonCancel=取消
+ButtonYes=是(&Y)
+ButtonYesToAll=全是(&A)
+ButtonNo=否(&N)
+ButtonNoToAll=全否(&O)
+ButtonFinish=完成(&F)
+ButtonBrowse=浏览(&B)...
+ButtonWizardBrowse=浏览(&R)...
+ButtonNewFolder=新建文件夹(&M)
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=选择安装语言
+SelectLanguageLabel=选择安装时使用的语言。
+
+; *** Common wizard text
+ClickNext=点击“下一步”继续，或点击“取消”退出安装程序。
+BeveledLabel=
+BrowseDialogTitle=浏览文件夹
+BrowseDialogLabel=在下面的列表中选择一个文件夹，然后点击“确定”。
+NewFolderName=新建文件夹
+
+; *** "Welcome" wizard page
+WelcomeLabel1=欢迎使用 [name] 安装向导
+WelcomeLabel2=即将在您的计算机上安装 [name/ver]。%n%n建议您在继续安装前关闭所有其他应用程序。
+
+; *** "Password" wizard page
+WizardPassword=密码
+PasswordLabel1=此安装程序需要密码验证。
+PasswordLabel3=请输入密码，然后点击“下一步”继续。密码区分大小写。
+PasswordEditLabel=密码(&P)：
+IncorrectPassword=您输入的密码不正确，请重新输入。
+
+; *** "License Agreement" wizard page
+WizardLicense=许可协议
+LicenseLabel=请在继续安装前阅读以下重要信息。
+LicenseLabel3=请阅读下列许可协议。在继续安装前您必须同意这些协议条款。
+LicenseAccepted=我同意此协议(&A)
+LicenseNotAccepted=我不同意此协议(&D)
+
+; *** "Information" wizard pages
+WizardInfoBefore=信息
+InfoBeforeLabel=请在继续安装前阅读以下重要信息。
+InfoBeforeClickLabel=准备好继续安装后，点击“下一步”。
+WizardInfoAfter=信息
+InfoAfterLabel=请在继续安装前阅读以下重要信息。
+InfoAfterClickLabel=准备好继续安装后，点击“下一步”。
+
+; *** "User Information" wizard page
+WizardUserInfo=用户信息
+UserInfoDesc=请输入您的信息。
+UserInfoName=用户名(&U)：
+UserInfoOrg=组织(&O)：
+UserInfoSerial=序列号(&S)：
+UserInfoNameRequired=请输入用户名。
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=选择目标位置
+SelectDirDesc=您想将 [name] 安装在哪里？
+SelectDirLabel3=安装程序将安装 [name] 到下面的文件夹中。
+SelectDirBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+DiskSpaceGBLabel=至少需要有 [gb] GB 的可用磁盘空间。
+DiskSpaceMBLabel=至少需要有 [mb] MB 的可用磁盘空间。
+CannotInstallToNetworkDrive=安装程序无法安装到一个网络驱动器。
+CannotInstallToUNCPath=安装程序无法安装到一个 UNC 路径。
+InvalidPath=您必须输入一个带驱动器盘符的完整路径，例如：%n%nC:\App%n%n或UNC路径：%n%n\\server\share
+InvalidDrive=您选定的驱动器或 UNC 共享不存在或不能访问。请选择其他位置。
+DiskSpaceWarningTitle=磁盘空间不足
+DiskSpaceWarning=安装程序至少需要 %1 KB 的可用空间才能安装，但选定驱动器只有 %2 KB 的可用空间。%n%n您确定要继续吗？
+DirNameTooLong=文件夹名称或路径太长。
+InvalidDirName=文件夹名称无效。
+BadDirName32=文件夹名称不能包含下列任何字符：%n%n%1
+DirExistsTitle=文件夹已存在
+DirExists=文件夹：%n%n%1%n%n已经存在。您确定安装到这个文件夹中吗？
+DirDoesntExistTitle=文件夹不存在
+DirDoesntExist=文件夹：%n%n%1%n%n不存在。您想要创建此文件夹吗？
+
+; *** "Select Components" wizard page
+WizardSelectComponents=选择组件
+SelectComponentsDesc=您想安装哪些程序组件？
+SelectComponentsLabel2=选中您想安装的组件；取消您不想安装的组件。然后点击“下一步”继续。
+FullInstallation=完全安装
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=简洁安装
+CustomInstallation=自定义安装
+NoUninstallWarningTitle=组件已存在
+NoUninstallWarning=安装程序检测到下列组件已安装在您的计算机中：%n%n%1%n%n取消选中这些组件不会卸载它们。%n%n您确定要继续吗？
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=当前选择的组件需要至少 [gb] GB 的磁盘空间。
+ComponentsDiskSpaceMBLabel=当前选择的组件需要至少 [mb] MB 的磁盘空间。
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=选择附加任务
+SelectTasksDesc=您想要安装程序执行哪些附加任务？
+SelectTasksLabel2=选择您想要安装程序在安装 [name] 时执行的附加任务，然后点击“下一步”。
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=选择开始菜单文件夹
+SelectStartMenuFolderDesc=安装程序应该在哪里放置程序的快捷方式？
+SelectStartMenuFolderLabel3=安装程序将在下列“开始”菜单文件夹中创建程序的快捷方式。
+SelectStartMenuFolderBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+MustEnterGroupName=您必须输入一个文件夹名称。
+GroupNameTooLong=文件夹名称或路径太长。
+InvalidGroupName=文件夹名称无效。
+BadGroupName=文件夹名称不能包含下列任何字符：%n%n%1
+NoProgramGroupCheck2=不创建开始菜单文件夹(&D)
+
+; *** "Ready to Install" wizard page
+WizardReady=准备安装
+ReadyLabel1=安装程序准备就绪，现在可以开始安装 [name] 到您的计算机。
+ReadyLabel2a=点击“安装”继续此安装程序。如果您想重新查看或修改任何设置，点击“上一步”。
+ReadyLabel2b=点击“安装”继续此安装程序。
+ReadyMemoUserInfo=用户信息：
+ReadyMemoDir=目标位置：
+ReadyMemoType=安装类型：
+ReadyMemoComponents=已选择组件：
+ReadyMemoGroup=开始菜单文件夹：
+ReadyMemoTasks=附加任务：
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel2=正在下载文件...
+ButtonStopDownload=停止下载(&S)
+StopDownload=您确定要停止下载吗？
+ErrorDownloadAborted=下载已中止。
+ErrorDownloadFailed=下载失败：%1 %2。
+ErrorDownloadSizeFailed=获取大小失败：%1 %2。
+ErrorProgress=无效的进度：%1 / %2。
+ErrorFileSize=文件大小错误：预期 %1，实际 %2。
+
+; *** TExtractionWizardPage wizard page and ExtractArchive
+ExtractingLabel=正在提取文件...
+ButtonStopExtraction=停止提取(&S)
+StopExtraction=您确定要停止提取吗？
+ErrorExtractionAborted=提取已中止。
+ErrorExtractionFailed=提取失败：%1
+
+; *** Archive extraction failure details
+ArchiveIncorrectPassword=密码不正确。
+ArchiveIsCorrupted=压缩包已损坏。
+ArchiveUnsupportedFormat=不支持的压缩包格式。
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=正在准备安装
+PreparingDesc=安装程序正在准备安装 [name] 到您的计算机。
+PreviousInstallNotCompleted=先前的程序安装或卸载未完成，需要您重启计算机以完成该安装。%n%n在重启计算机后，再次运行安装程序以完成 [name] 的安装。
+CannotContinue=安装程序不能继续。请点击“取消”退出。
+ApplicationsFound=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。
+ApplicationsFound2=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动这些应用程序。
+CloseApplications=自动关闭应用程序(&A)
+DontCloseApplications=不要关闭应用程序(&D)
+ErrorCloseApplications=安装程序无法自动关闭所有应用程序。建议您在继续之前，关闭所有在使用需要由安装程序更新的文件的应用程序。
+PrepareToInstallNeedsRestart=安装程序必须重启您的计算机。计算机重启后，请再次运行安装程序以完成 [name] 的安装。%n%n要立即重启吗？
+
+; *** "Installing" wizard page
+WizardInstalling=正在安装
+InstallingLabel=安装程序正在安装 [name] 到您的计算机，请稍候。
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=完成 [name] 安装向导
+FinishedLabelNoIcons=安装程序已在您的计算机中安装了 [name]。
+FinishedLabel=安装程序已在您的计算机中安装了 [name]。您可以通过已安装的快捷方式运行此应用程序。
+ClickFinish=点击“完成”退出安装程序。
+FinishedRestartLabel=为完成 [name] 的安装，安装程序必须重新启动您的计算机。要立即重启吗？
+FinishedRestartMessage=为完成 [name] 的安装，安装程序必须重新启动您的计算机。%n%n要立即重启吗？
+ShowReadmeCheck=是，我想查阅自述文件
+YesRadio=是，立即重启计算机(&Y)
+NoRadio=否，稍后重启计算机(&N)
+; used for example as 'Run MyProg.exe'
+RunEntryExec=运行 %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=查阅 %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=安装程序需要下一张磁盘
+SelectDiskLabel2=请插入磁盘 %1 并点击“确定”。%n%n如果这个磁盘中的文件可以在下列文件夹之外的文件夹中找到，请输入正确的路径或点击“浏览”。
+PathLabel=路径(&P)：
+FileNotInDir2=“%2”中找不到文件“%1”。请插入正确的磁盘或选择其他文件夹。
+SelectDirectoryLabel=请指定下一张磁盘的位置。
+
+; *** Installation phase messages
+SetupAborted=安装程序未完成安装。%n%n请修正这个问题并重新运行安装程序。
+AbortRetryIgnoreSelectAction=选择操作
+AbortRetryIgnoreRetry=重试(&T)
+AbortRetryIgnoreIgnore=忽略错误并继续(&I)
+AbortRetryIgnoreCancel=取消安装
+RetryCancelSelectAction=选择操作
+RetryCancelRetry=重试(&T)
+RetryCancelCancel=取消
+
+; *** Installation status messages
+StatusClosingApplications=正在关闭应用程序...
+StatusCreateDirs=正在创建目录...
+StatusExtractFiles=正在提取文件...
+StatusDownloadFiles=正在下载文件...
+StatusCreateIcons=正在创建快捷方式...
+StatusCreateIniEntries=正在创建 INI 条目...
+StatusCreateRegistryEntries=正在创建注册表条目...
+StatusRegisterFiles=正在注册文件...
+StatusSavingUninstall=正在保存卸载信息...
+StatusRunProgram=正在完成安装...
+StatusRestartingApplications=正在重启应用程序...
+StatusRollback=正在撤销更改...
+
+; *** Misc. errors
+ErrorInternal2=内部错误：%1。
+ErrorFunctionFailedNoCode=%1 失败。
+ErrorFunctionFailed=%1 失败；错误代码 %2。
+ErrorFunctionFailedWithMessage=%1 失败；错误代码 %2。%n%3
+ErrorExecutingProgram=无法执行文件：%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=打开注册表项时出错：%n%1\%2
+ErrorRegCreateKey=创建注册表项时出错：%n%1\%2
+ErrorRegWriteKey=写入注册表项时出错：%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=在文件“%1”中创建 INI 条目时出错。
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=跳过此文件(&S)（不推荐）
+FileAbortRetryIgnoreIgnoreNotRecommended=忽略错误并继续(&I)（不推荐）
+SourceIsCorrupted=源文件已损坏。
+SourceDoesntExist=源文件“%1”不存在。
+SourceVerificationFailed=源文件验证失败：%1
+VerificationSignatureDoesntExist=签名文件“%1”不存在。
+VerificationSignatureInvalid=签名文件“%1”无效。
+VerificationKeyNotFound=签名文件“%1”使用了未知的密钥。
+VerificationFileNameIncorrect=文件名不正确。
+VerificationFileTagIncorrect=文件标签不正确。
+VerificationFileSizeIncorrect=文件大小不正确。
+VerificationFileHashIncorrect=文件哈希值不正确。
+ExistingFileReadOnly2=无法替换已存在的文件，它是只读的。
+ExistingFileReadOnlyRetry=移除只读属性并重试(&R)
+ExistingFileReadOnlyKeepExisting=保留已存在的文件(&K)
+ErrorReadingExistingDest=尝试读取已存在的文件时出错：
+FileExistsSelectAction=选择操作
+FileExists2=文件已经存在。
+FileExistsOverwriteExisting=覆盖已存在的文件(&O)
+FileExistsKeepExisting=保留已存在的文件(&K)
+FileExistsOverwriteOrKeepAll=为接下来的冲突文件执行此操作(&D)
+ExistingFileNewerSelectAction=选择操作
+ExistingFileNewer2=已存在的文件比安装程序将要安装的文件还要新。
+ExistingFileNewerOverwriteExisting=覆盖已存在的文件(&O)
+ExistingFileNewerKeepExisting=保留已存在的文件(&K)（推荐）
+ExistingFileNewerOverwriteOrKeepAll=为接下来的冲突文件执行此操作(&D)
+ErrorChangingAttr=尝试更改下列已存在的文件属性时出错：
+ErrorCreatingTemp=尝试在目标目录创建文件时出错：
+ErrorReadingSource=尝试读取下列源文件时出错：
+ErrorCopying=尝试复制下列文件时出错：
+ErrorDownloading=尝试下载文件时出错：
+ErrorExtracting=尝试提取压缩包时出错：
+ErrorReplacingExistingFile=尝试替换已存在的文件时出错：
+ErrorRestartReplace=重启并替换失败：
+ErrorRenamingTemp=尝试重命名下列目标目录中的一个文件时出错：
+ErrorRegisterServer=无法注册 DLL/OCX：%1
+ErrorRegSvr32Failed=RegSvr32 失败；退出代码 %1。
+ErrorRegisterTypeLib=无法注册类型库：%1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 位
+UninstallDisplayNameMark64Bit=64 位
+UninstallDisplayNameMarkAllUsers=所有用户
+UninstallDisplayNameMarkCurrentUser=当前用户
+
+; *** Post-installation errors
+ErrorOpeningReadme=尝试打开自述文件时出错。
+ErrorRestartingComputer=安装程序无法重启计算机，请手动重启。
+
+; *** Uninstaller messages
+UninstallNotFound=文件“%1”不存在。无法卸载。
+UninstallOpenError=文件“%1”不能被打开。无法卸载
+UninstallUnsupportedVer=此版本的卸载程序无法识别卸载日志文件“%1”的格式。无法卸载。
+UninstallUnknownEntry=卸载日志中遇到一个未知条目（%1）。
+ConfirmUninstall=您确认要完全移除 %1 及其所有组件吗？
+UninstallOnlyOnWin64=仅允许在 64 位 Windows 中卸载此程序。
+OnlyAdminCanUninstall=仅使用管理员权限的用户能完成此卸载。
+UninstallStatusLabel=正在从您的计算机中移除 %1，请稍候。
+UninstalledAll=已顺利从您的计算机中移除 %1。
+UninstalledMost=%1 卸载完成。%n%n有部分内容未能被删除，但您可以手动删除它们。
+UninstalledAndNeedsRestart=为完成 %1 的卸载，需要重启您的计算机。%n%n要立即重启吗？
+UninstallDataCorrupted=文件“%1”已损坏。无法卸载。
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=删除共享文件？
+ConfirmDeleteSharedFile2=系统表示下列共享文件已不再有任何程序使用。您希望卸载程序删除此共享文件吗？%n%n如果仍有程序正在使用此文件，删除后这些程序可能无法正常运行。如果您不能确定，请选择“否”，保留此文件在系统中不会造成任何损害。
+SharedFileNameLabel=文件名：
+SharedFileLocationLabel=位置：
+WizardUninstalling=卸载状态
+StatusUninstalling=正在卸载 %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=正在安装 %1。
+ShutdownBlockReasonUninstallingApp=正在卸载 %1。
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 版本 %2
+AdditionalIcons=附加快捷方式：
+CreateDesktopIcon=创建桌面快捷方式(&D)
+CreateQuickLaunchIcon=创建快速启动栏快捷方式(&Q)
+ProgramOnTheWeb=%1 网站
+UninstallProgram=卸载 %1
+LaunchProgram=运行 %1
+AssocFileExtension=将 %2 文件扩展名与 %1 建立关联(&A)
+AssocingFileExtension=正在将 %2 文件扩展名与 %1 建立关联...
+AutoStartProgramGroupDescription=启动：
+AutoStartProgram=自动启动 %1
+AddonHostProgramNotFound=您选择的文件夹中无法找到 %1。%n%n您确定要继续吗？

--- a/RHI Setup.iss
+++ b/RHI Setup.iss
@@ -38,9 +38,18 @@ OutputBaseFilename=RHI-Setup
 SetupIconFile=RenoDXCommander\icon.ico
 SolidCompression=yes
 WizardStyle=modern dynamic
+ShowLanguageDialog=yes
+LanguageDetectionMethod=uiLanguage
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "chinesesimplified"; MessagesFile: "Installer\Languages\ChineseSimplified.isl"
+
+[CustomMessages]
+english.SelectLanguageTitle=Select RHI Language
+english.SelectLanguageLabel=Select the language for Setup and RHI:
+chinesesimplified.SelectLanguageTitle=选择 RHI 语言
+chinesesimplified.SelectLanguageLabel=选择安装向导和 RHI 使用的语言：
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
@@ -76,6 +85,55 @@ begin
   end;
 end;
 
+procedure SetRhiLanguage(const LanguageCode: String);
+var
+  SettingsDir, SettingsFile, Content: String;
+  InputLines, OutputLines: TArrayOfString;
+  KeyPos, ColonPos, QuoteStart, QuoteEnd, RelativePos, I: Integer;
+begin
+  SettingsDir := ExpandConstant('{localappdata}\RHI');
+  SettingsFile := SettingsDir + '\settings.json';
+  if not DirExists(SettingsDir) then
+    ForceDirectories(SettingsDir);
+
+  Content := '';
+  if LoadStringsFromFile(SettingsFile, InputLines) then
+  begin
+    for I := 0 to GetArrayLength(InputLines) - 1 do
+    begin
+      if I > 0 then
+        Content := Content + #13#10;
+      Content := Content + InputLines[I];
+    end;
+  end
+  else
+    Content := '{}';
+
+  // settings.json is produced by System.Text.Json and UiLanguage values contain no escapes.
+  KeyPos := Pos('"UiLanguage"', Content);
+  if KeyPos > 0 then
+  begin
+    RelativePos := Pos(':', Copy(Content, KeyPos, MaxInt));
+    ColonPos := KeyPos + RelativePos - 1;
+    RelativePos := Pos('"', Copy(Content, ColonPos + 1, MaxInt));
+    QuoteStart := ColonPos + RelativePos;
+    RelativePos := Pos('"', Copy(Content, QuoteStart + 1, MaxInt));
+    QuoteEnd := QuoteStart + RelativePos;
+    Delete(Content, QuoteStart, QuoteEnd - QuoteStart + 1);
+    Insert(LanguageCode, Content, QuoteStart);
+  end
+  else if Content = '' then
+    Content := '{"UiLanguage":"' + LanguageCode + '"}'
+  else if Trim(Content) = '{}' then
+    Content := '{"UiLanguage":"' + LanguageCode + '"}'
+  else
+    Insert('"UiLanguage":"' + LanguageCode + '",', Content, Pos('{', Content) + 1);
+
+  SetArrayLength(OutputLines, 1);
+  OutputLines[0] := Content;
+  SaveStringsToUTF8File(SettingsFile, OutputLines, False);
+end;
+
 function InitializeSetup(): Boolean;
 var
   SignalDir, SignalPath: String;
@@ -102,5 +160,24 @@ begin
   end;
 
   // If still running, Inno's default CloseApplications will handle it
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  LanguageFileLines: TArrayOfString;
+begin
+  if CurStep = ssPostInstall then
+  begin
+    if ActiveLanguage = 'chinesesimplified' then
+      SetRhiLanguage('zh-CN')
+    else
+      SetRhiLanguage('en-US');
+
+    // Store a machine-level default so the choice also works when Setup is
+    // elevated under a different account than the person who launched it.
+    SetArrayLength(LanguageFileLines, 1);
+    LanguageFileLines[0] := ActiveLanguage;
+    SaveStringsToUTF8File(ExpandConstant('{app}\ui-language.txt'), LanguageFileLines, False);
+  end;
 end;
 

--- a/RHI Setup.iss
+++ b/RHI Setup.iss
@@ -110,6 +110,11 @@ begin
     WaitCount := WaitCount + 1;
   end;
 
+  // The app treats this file as a shutdown command on every launch.
+  // Remove it after waiting so the freshly installed app does not exit immediately.
+  if FileExists(SignalPath) then
+    DeleteFile(SignalPath);
+
   // If still running, Inno's default CloseApplications will handle it
 end;
 
@@ -117,9 +122,14 @@ procedure CurStepChanged(CurStep: TSetupStep);
 var
   LanguageFileLines: TArrayOfString;
   LanguageCode: String;
+  ShutdownSignalPath: String;
 begin
   if CurStep = ssPostInstall then
   begin
+    ShutdownSignalPath := ExpandConstant('{localappdata}\RHI\rhi_shutdown_requested');
+    if FileExists(ShutdownSignalPath) then
+      DeleteFile(ShutdownSignalPath);
+
     if ActiveLanguage = 'chinesesimplified' then
       LanguageCode := 'zh-CN'
     else

--- a/RHI Setup.iss
+++ b/RHI Setup.iss
@@ -47,7 +47,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "{#PublishDir}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#PublishDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#PublishDir}\*"; DestDir: "{app}"; Excludes: "*.pdb"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/RHI Setup.iss
+++ b/RHI Setup.iss
@@ -85,55 +85,6 @@ begin
   end;
 end;
 
-procedure SetRhiLanguage(const LanguageCode: String);
-var
-  SettingsDir, SettingsFile, Content: String;
-  InputLines, OutputLines: TArrayOfString;
-  KeyPos, ColonPos, QuoteStart, QuoteEnd, RelativePos, I: Integer;
-begin
-  SettingsDir := ExpandConstant('{localappdata}\RHI');
-  SettingsFile := SettingsDir + '\settings.json';
-  if not DirExists(SettingsDir) then
-    ForceDirectories(SettingsDir);
-
-  Content := '';
-  if LoadStringsFromFile(SettingsFile, InputLines) then
-  begin
-    for I := 0 to GetArrayLength(InputLines) - 1 do
-    begin
-      if I > 0 then
-        Content := Content + #13#10;
-      Content := Content + InputLines[I];
-    end;
-  end
-  else
-    Content := '{}';
-
-  // settings.json is produced by System.Text.Json and UiLanguage values contain no escapes.
-  KeyPos := Pos('"UiLanguage"', Content);
-  if KeyPos > 0 then
-  begin
-    RelativePos := Pos(':', Copy(Content, KeyPos, MaxInt));
-    ColonPos := KeyPos + RelativePos - 1;
-    RelativePos := Pos('"', Copy(Content, ColonPos + 1, MaxInt));
-    QuoteStart := ColonPos + RelativePos;
-    RelativePos := Pos('"', Copy(Content, QuoteStart + 1, MaxInt));
-    QuoteEnd := QuoteStart + RelativePos;
-    Delete(Content, QuoteStart, QuoteEnd - QuoteStart + 1);
-    Insert(LanguageCode, Content, QuoteStart);
-  end
-  else if Content = '' then
-    Content := '{"UiLanguage":"' + LanguageCode + '"}'
-  else if Trim(Content) = '{}' then
-    Content := '{"UiLanguage":"' + LanguageCode + '"}'
-  else
-    Insert('"UiLanguage":"' + LanguageCode + '",', Content, Pos('{', Content) + 1);
-
-  SetArrayLength(OutputLines, 1);
-  OutputLines[0] := Content;
-  SaveStringsToUTF8File(SettingsFile, OutputLines, False);
-end;
-
 function InitializeSetup(): Boolean;
 var
   SignalDir, SignalPath: String;
@@ -173,8 +124,6 @@ begin
       LanguageCode := 'zh-CN'
     else
       LanguageCode := 'en-US';
-
-    SetRhiLanguage(LanguageCode);
 
     // Store a machine-level default so the choice also works when Setup is
     // elevated under a different account than the person who launched it.

--- a/RHI Setup.iss
+++ b/RHI Setup.iss
@@ -3,10 +3,11 @@
 ; Non-commercial use only
 
 #define MyAppName "RHI"
-#define MyAppVersion "2.0.1"
+#define MyAppVersion "2.5.4"
 #define MyAppPublisher "RankFTW"
 #define MyAppURL "www.github.com/rankftw"
 #define MyAppExeName "RHI.exe"
+#define PublishDir "publish\RHI-2.5.4-zhCN-win-x64"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -32,9 +33,9 @@ ArchitecturesInstallIn64BitMode=x64compatible
 DisableProgramGroupPage=yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only).
 ;PrivilegesRequired=lowest
-OutputDir=C:\Users\Mark\OneDrive\Documents\RDXC\Installers
+OutputDir=installers
 OutputBaseFilename=RHI-Setup
-SetupIconFile=C:\Users\Mark\OneDrive\Documents\RDXC\icon.ico
+SetupIconFile=RenoDXCommander\icon.ico
 SolidCompression=yes
 WizardStyle=modern dynamic
 
@@ -45,8 +46,8 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "C:\Users\Mark\OneDrive\Documents\RDXC\Publish\RHI\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\Mark\OneDrive\Documents\RDXC\Publish\RHI\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#PublishDir}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PublishDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/RHI Setup.iss
+++ b/RHI Setup.iss
@@ -165,18 +165,21 @@ end;
 procedure CurStepChanged(CurStep: TSetupStep);
 var
   LanguageFileLines: TArrayOfString;
+  LanguageCode: String;
 begin
   if CurStep = ssPostInstall then
   begin
     if ActiveLanguage = 'chinesesimplified' then
-      SetRhiLanguage('zh-CN')
+      LanguageCode := 'zh-CN'
     else
-      SetRhiLanguage('en-US');
+      LanguageCode := 'en-US';
+
+    SetRhiLanguage(LanguageCode);
 
     // Store a machine-level default so the choice also works when Setup is
     // elevated under a different account than the person who launched it.
     SetArrayLength(LanguageFileLines, 1);
-    LanguageFileLines[0] := ActiveLanguage;
+    LanguageFileLines[0] := LanguageCode;
     SaveStringsToUTF8File(ExpandConstant('{app}\ui-language.txt'), LanguageFileLines, False);
   end;
 end;

--- a/RenoDXCommander.Tests/LocalizationTests.cs
+++ b/RenoDXCommander.Tests/LocalizationTests.cs
@@ -1,0 +1,28 @@
+using RenoDXCommander.Services;
+using Xunit;
+
+namespace RenoDXCommander.Tests;
+
+public class LocalizationTests
+{
+    [Theory]
+    [InlineData(null, UiLanguage.Auto)]
+    [InlineData("", UiLanguage.Auto)]
+    [InlineData("AUTO", UiLanguage.Auto)]
+    [InlineData("en", UiLanguage.English)]
+    [InlineData("EN-US", UiLanguage.English)]
+    [InlineData("zh", UiLanguage.SimplifiedChinese)]
+    [InlineData("zh-HANS", UiLanguage.SimplifiedChinese)]
+    [InlineData("zh-CN", UiLanguage.SimplifiedChinese)]
+    public void Normalize_Aliases_ReturnCanonicalLanguage(string? input, string expected)
+    {
+        Assert.Equal(expected, UiLanguage.Normalize(input));
+    }
+
+    [Fact]
+    public void SupportedLanguages_ContainsEnglishAndSimplifiedChinese()
+    {
+        Assert.Contains(UiLanguage.English, UiLanguage.SupportedLanguages);
+        Assert.Contains(UiLanguage.SimplifiedChinese, UiLanguage.SupportedLanguages);
+    }
+}

--- a/RenoDXCommander/App.xaml.cs
+++ b/RenoDXCommander/App.xaml.cs
@@ -132,7 +132,21 @@ public partial class App : Application
         // ── One-time migration from legacy AppData folders ───────
         MigrateLegacyAppData();
         DownloadsMigrationService.RunOnce();
-        UiLanguage.Apply(SettingsViewModel.LoadSettingsFile().GetValueOrDefault("UiLanguage"));
+        var uiLanguage = SettingsViewModel.LoadSettingsFile().GetValueOrDefault("UiLanguage");
+        if (string.IsNullOrWhiteSpace(uiLanguage))
+        {
+            try
+            {
+                var installerLanguagePath = Path.Combine(AppContext.BaseDirectory, "ui-language.txt");
+                if (File.Exists(installerLanguagePath))
+                    uiLanguage = File.ReadAllText(installerLanguagePath).Trim();
+            }
+            catch (Exception ex)
+            {
+                CrashReporter.Log($"[App.OnLaunched] Failed to read installer language — {ex.Message}");
+            }
+        }
+        UiLanguage.Apply(uiLanguage);
 
         // Single-instance check: if another instance is already running,
         // forward the addon file path and exit immediately.

--- a/RenoDXCommander/App.xaml.cs
+++ b/RenoDXCommander/App.xaml.cs
@@ -132,6 +132,7 @@ public partial class App : Application
         // ── One-time migration from legacy AppData folders ───────
         MigrateLegacyAppData();
         DownloadsMigrationService.RunOnce();
+        UiLanguage.Apply(SettingsViewModel.LoadSettingsFile().GetValueOrDefault("UiLanguage"));
 
         // Single-instance check: if another instance is already running,
         // forward the addon file path and exit immediately.

--- a/RenoDXCommander/App.xaml.cs
+++ b/RenoDXCommander/App.xaml.cs
@@ -127,7 +127,7 @@ public partial class App : Application
         Services = services.BuildServiceProvider();
     }
 
-    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    protected override async void OnLaunched(LaunchActivatedEventArgs args)
     {
         // ── One-time migration from legacy AppData folders ───────
         MigrateLegacyAppData();
@@ -137,7 +137,9 @@ public partial class App : Application
         {
             try
             {
-                var installerLanguagePath = Path.Combine(AppContext.BaseDirectory, "ui-language.txt");
+                var installerLanguagePath = Path.Combine(
+                    Path.GetDirectoryName(Environment.ProcessPath) ?? AppContext.BaseDirectory,
+                    "ui-language.txt");
                 if (File.Exists(installerLanguagePath))
                     uiLanguage = File.ReadAllText(installerLanguagePath).Trim();
             }
@@ -146,7 +148,8 @@ public partial class App : Application
                 CrashReporter.Log($"[App.OnLaunched] Failed to read installer language — {ex.Message}");
             }
         }
-        UiLanguage.Apply(uiLanguage);
+        var localizerReady = await LocalizationService.InitializeAsync(uiLanguage);
+        CrashReporter.Log($"[App.OnLaunched] UI language '{UiLanguage.Resolve(uiLanguage)}' initialized (ready={localizerReady})");
 
         // Single-instance check: if another instance is already running,
         // forward the addon file path and exit immediately.

--- a/RenoDXCommander/MainWindow.Events.Settings.cs
+++ b/RenoDXCommander/MainWindow.Events.Settings.cs
@@ -67,6 +67,9 @@ public sealed partial class MainWindow
     private void CustomShadersCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         => _settingsHandler.CustomShadersCombo_SelectionChanged(sender, e);
 
+    private void UiLanguageCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        => _settingsHandler.UiLanguageCombo_SelectionChanged(sender, e);
+
     private void ApplyScreenshotPath_Click(object sender, RoutedEventArgs e)
         => _settingsHandler.ApplyScreenshotPath_Click(sender, e);
 

--- a/RenoDXCommander/MainWindow.xaml
+++ b/RenoDXCommander/MainWindow.xaml
@@ -38,20 +38,20 @@
                         <TextBlock FontSize="15" FontWeight="Bold">
                             <Run Text="RHI" Foreground="{StaticResource AccentTealBrush}"/>
                         </TextBlock>
-                        <TextBlock Text="Simplified PC Gaming" FontSize="10" Foreground="{StaticResource AccentTealDimBrush}"/>
+                        <TextBlock x:Uid="App_Subtitle" Text="Simplified PC Gaming" FontSize="10" Foreground="{StaticResource AccentTealDimBrush}"/>
                     </StackPanel>
                 </StackPanel>
 
                 <!-- Action buttons -->
                 <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <Button x:Name="NewModsBtn" Content="New Mods Available"
+                    <Button x:Name="NewModsBtn" x:Uid="Toolbar_NewModsButton" Content="New Mods Available"
                             Click="NewModsButton_Click"
                             Visibility="{x:Bind ViewModel.NewWikiModsButtonVisibility, Mode=OneWay}"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentGreenBrush}"
                             BorderBrush="{StaticResource AccentGreenBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="New RenoDX mods have been added to the wiki"/>
-                    <Button x:Name="FaqBtn" Content="Quick Start"
+                    <Button x:Name="FaqBtn" x:Uid="Toolbar_FaqButton" Content="Quick Start"
                             Click="FaqButton_Click"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
@@ -60,28 +60,28 @@
 
                     <Border Width="1" Height="20" Background="{StaticResource BorderSubtleBrush}" Margin="4,0"/>
 
-                    <Button x:Name="RefreshBtn" Content="Refresh"
+                    <Button x:Name="RefreshBtn" x:Uid="Toolbar_RefreshButton" Content="Refresh"
                             Click="RefreshButton_Click"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Rescan game library and fetch latest mod info"/>
-                    <Button x:Name="ShadersAddonsBtn" Content="Shaders/Addons"
+                    <Button x:Name="ShadersAddonsBtn" x:Uid="Toolbar_ShadersAddonsButton" Content="Shaders/Addons"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Manage global shaders and ReShade addons">
                         <Button.Flyout>
                             <MenuFlyout Placement="Bottom">
-                                <MenuFlyoutItem x:Name="ChooseShadersItem" Text="Global Shaders" Click="ChooseShadersButton_Click"/>
-                                <MenuFlyoutItem x:Name="ReShadeAddonsItem" Text="ReShade Addons" Click="ReShadeAddonsButton_Click"/>
+                                <MenuFlyoutItem x:Name="ChooseShadersItem" x:Uid="Toolbar_ChooseShadersItem" Text="Global Shaders" Click="ChooseShadersButton_Click"/>
+                                <MenuFlyoutItem x:Name="ReShadeAddonsItem" x:Uid="Toolbar_ReShadeAddonsItem" Text="ReShade Addons" Click="ReShadeAddonsButton_Click"/>
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>
 
                     <Border Width="1" Height="20" Background="{StaticResource BorderSubtleBrush}" Margin="4,0"/>
 
-                    <Button x:Name="UpdateBtn" Content="Update All"
+                    <Button x:Name="UpdateBtn" x:Uid="Toolbar_UpdateButton" Content="Update All"
                             Click="UpdateAllButton_Click"
                             Background="{StaticResource SurfaceInputBrush}"
                             Foreground="{StaticResource TextTertiaryBrush}"
@@ -92,31 +92,31 @@
 
                     <Border Width="1" Height="20" Background="{StaticResource BorderSubtleBrush}" Margin="4,0"/>
 
-                    <Button x:Name="LinksBtn" Content="Links"
+                    <Button x:Name="LinksBtn" x:Uid="Toolbar_LinksButton" Content="Links"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Useful links and resources">
                         <Button.Flyout>
                             <MenuFlyout Placement="Bottom">
-                                <MenuFlyoutItem Text="RenoDX Wiki" Click="LinkRenoDxWiki_Click"/>
-                                <MenuFlyoutItem Text="Luma Wiki" Click="LinkLumaWiki_Click"/>
-                                <MenuFlyoutItem Text="RHI GitHub" Click="LinkRhiGithub_Click"/>
-                                <MenuFlyoutItem Text="ReLimiter GitHub" Click="LinkReLimiterGithub_Click"/>
+                                <MenuFlyoutItem x:Uid="Toolbar_RenoDXWikiItem" Text="RenoDX Wiki" Click="LinkRenoDxWiki_Click"/>
+                                <MenuFlyoutItem x:Uid="Toolbar_LumaWikiItem" Text="Luma Wiki" Click="LinkLumaWiki_Click"/>
+                                <MenuFlyoutItem x:Uid="Toolbar_RhiGitHubItem" Text="RHI GitHub" Click="LinkRhiGithub_Click"/>
+                                <MenuFlyoutItem x:Uid="Toolbar_ReLimiterGitHubItem" Text="ReLimiter GitHub" Click="LinkReLimiterGithub_Click"/>
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>
-                    <Button x:Name="SupportBtn" Content="Help"
+                    <Button x:Name="SupportBtn" x:Uid="Toolbar_SupportButton" Content="Help"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Support and help resources">
                         <Button.Flyout>
                             <MenuFlyout Placement="Bottom">
-                                <MenuFlyoutItem Text="Discord" Click="SupportDiscord_Click"/>
-                                <MenuFlyoutItem Text="Guide" Click="SupportGuide_Click"/>
-                                <MenuFlyoutItem Text="Ko-fi" Click="SupportKofi_Click"/>
-                                <MenuFlyoutItem Text="About" Click="AboutButton_Click"/>
+                                <MenuFlyoutItem x:Uid="Toolbar_DiscordItem" Text="Discord" Click="SupportDiscord_Click"/>
+                                <MenuFlyoutItem x:Uid="Toolbar_GuideItem" Text="Guide" Click="SupportGuide_Click"/>
+                                <MenuFlyoutItem x:Uid="Toolbar_KofiItem" Text="Ko-fi" Click="SupportKofi_Click"/>
+                                <MenuFlyoutItem x:Uid="Toolbar_AboutItem" Text="About" Click="AboutButton_Click"/>
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>
@@ -129,7 +129,7 @@
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Toggle between Detail and Simple view"/>
-                    <Button x:Name="SettingsBtn" Content="Settings"
+                    <Button x:Name="SettingsBtn" x:Uid="Toolbar_SettingsButton" Content="Settings"
                             Click="SettingsButton_Click" IsEnabled="False"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
@@ -147,7 +147,7 @@
                         Spacing="16" Visibility="Collapsed" Canvas.ZIndex="10">
                 <ProgressRing x:Name="LoadingRing" IsActive="True" Width="48" Height="48"
                               Foreground="{StaticResource AccentBlueBrush}"/>
-                <TextBlock x:Name="LoadingTitle" Text="Loading..." FontSize="16"
+                <TextBlock x:Name="LoadingTitle" x:Uid="Loading_Title" Text="Loading..." FontSize="16"
                            Foreground="{StaticResource ChipTextBrush}" HorizontalAlignment="Center"/>
                 <TextBlock x:Name="LoadingSubtitle" Text="" FontSize="12"
                            Foreground="{StaticResource TextDisabledBrush}" HorizontalAlignment="Center"/>
@@ -178,14 +178,14 @@
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBox x:Name="SearchBox" Grid.Column="0"
+                                <TextBox x:Name="SearchBox" Grid.Column="0" x:Uid="Sidebar_SearchBox"
                                          PlaceholderText="Filter games..."
                                          TextChanged="SearchBox_TextChanged"
                                          Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource TextSecondaryBrush}"
                                          BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
                                          CornerRadius="8" Padding="10,7"
                                          FontSize="12"/>
-                                <Button x:Name="SaveFilterButton" Grid.Column="1"
+                                <Button x:Name="SaveFilterButton" Grid.Column="1" x:Uid="Sidebar_SaveFilterButton"
                                         Content="+"
                                         Click="SaveFilterButton_Click"
                                         Visibility="Collapsed"
@@ -198,7 +198,7 @@
                                         FontSize="14" FontWeight="Bold"
                                         VerticalAlignment="Center"
                                         ToolTipService.ToolTip="Save current search as a custom filter"/>
-                                <Button x:Name="AddGameBtn" Grid.Column="2"
+                                <Button x:Name="AddGameBtn" Grid.Column="2" x:Uid="Sidebar_AddGameButton"
                                         Content="+"
                                         Click="AddGameButton_Click"
                                         Background="{StaticResource AccentGreenBgBrush}"
@@ -218,33 +218,33 @@
                                 BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
                             <StackPanel Spacing="4">
                                 <StackPanel Orientation="Horizontal" Spacing="4">
-                                    <Button x:Name="FilterDetected" Content="All Games" Tag="Detected"
+                                    <Button x:Name="FilterDetected" x:Uid="Sidebar_FilterDetected" Content="All Games" Tag="Detected"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipActiveBrush}" Foreground="White"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterInstalled" Content="Installed" Tag="Installed"
+                                    <Button x:Name="FilterInstalled" x:Uid="Sidebar_FilterInstalled" Content="Installed" Tag="Installed"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterFavourites" Content="Favourites" Tag="Favourites"
+                                    <Button x:Name="FilterFavourites" x:Uid="Sidebar_FilterFavourites" Content="Favourites" Tag="Favourites"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterHidden" Content="Hidden" Tag="Hidden"
+                                    <Button x:Name="FilterHidden" x:Uid="Sidebar_FilterHidden" Content="Hidden" Tag="Hidden"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Spacing="4">
-                                    <Button x:Name="FilterUnreal" Content="Unreal" Tag="Unreal"
+                                    <Button x:Name="FilterUnreal" x:Uid="Sidebar_FilterUnreal" Content="Unreal" Tag="Unreal"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterUnity" Content="Unity" Tag="Unity"
+                                    <Button x:Name="FilterUnity" x:Uid="Sidebar_FilterUnity" Content="Unity" Tag="Unity"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterOther" Content="Other" Tag="Other"
+                                    <Button x:Name="FilterOther" x:Uid="Sidebar_FilterOther" Content="Other" Tag="Other"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
@@ -1200,12 +1200,12 @@
                 <Border Grid.Row="0" Padding="24,12,24,10" Background="Transparent"
                         BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
                     <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                        <Button x:Name="SettingsBackBtn" Content="← Back to Games"
+                        <Button x:Name="SettingsBackBtn" x:Uid="Settings_BackButton" Content="← Back to Games"
                                 Click="SettingsBack_Click"
                                 Background="{StaticResource SurfaceOverlayBrush}" Foreground="{StaticResource TextSecondaryBrush}"
                                 BorderBrush="{StaticResource BorderDefaultBrush}" BorderThickness="1"
                                 CornerRadius="8" Padding="12,6" FontSize="12"/>
-                        <TextBlock Text="Settings" FontSize="20" FontWeight="Bold"
+                        <TextBlock x:Uid="Settings_Title" Text="Settings" FontSize="20" FontWeight="Bold"
                                    Foreground="{StaticResource TextPrimaryBrush}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Border>
@@ -1216,12 +1216,45 @@
                                 HorizontalAlignment="Center">
 
                         <!-- ══════════════════════════════════════════════════════════
+                             CARD 0: LANGUAGE
+                             ══════════════════════════════════════════════════════════ -->
+                        <Border Background="{StaticResource SurfaceRaisedBrush}" CornerRadius="10" Padding="20,16"
+                                BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1">
+                            <StackPanel Spacing="8">
+                                <TextBlock x:Uid="Settings_Language_Title" Text="Language" FontSize="15" FontWeight="Bold"
+                                           Foreground="{StaticResource TextPrimaryBrush}"/>
+                                <TextBlock x:Uid="Settings_Language_Description" Text="Choose the interface language. New languages can be added as additional resource files."
+                                           TextWrapping="Wrap" FontSize="11"
+                                           Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"/>
+                                <Grid ColumnSpacing="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" x:Uid="Settings_Language_Label" Text="Interface language" FontSize="12"
+                                               Foreground="{StaticResource TextSecondaryBrush}"
+                                               VerticalAlignment="Center"/>
+                                    <ComboBox Grid.Column="1" x:Name="UiLanguageCombo" x:FieldModifier="internal"
+                                              SelectionChanged="UiLanguageCombo_SelectionChanged"
+                                              FontSize="12" HorizontalAlignment="Stretch">
+                                        <ComboBoxItem x:Uid="Settings_Language_Auto" Content="Follow system" Tag="auto"/>
+                                        <ComboBoxItem x:Uid="Settings_Language_English" Content="English (United States)" Tag="en-US"/>
+                                        <ComboBoxItem x:Uid="Settings_Language_SimplifiedChinese" Content="Simplified Chinese" Tag="zh-CN"/>
+                                    </ComboBox>
+                                </Grid>
+                                <TextBlock x:Uid="Settings_Language_RestartNote" Text="Language changes take effect after restarting RHI."
+                                           TextWrapping="Wrap" FontSize="11"
+                                           Foreground="{StaticResource TextTertiaryBrush}"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- ══════════════════════════════════════════════════════════
                              CARD 1: GAME LIBRARY
                              ══════════════════════════════════════════════════════════ -->
                         <Border Background="{StaticResource SurfaceRaisedBrush}" CornerRadius="10" Padding="20,16"
                                 BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1">
                             <StackPanel Spacing="12">
-                            <TextBlock Text="Component Updates" FontSize="15" FontWeight="Bold"
+                            <TextBlock x:Uid="Settings_ComponentUpdates_Title" Text="Component Updates" FontSize="15" FontWeight="Bold"
                                        Foreground="{StaticResource TextPrimaryBrush}"/>
                             <Grid ColumnSpacing="0" RowSpacing="8">
                                 <Grid.ColumnDefinitions>
@@ -1237,12 +1270,12 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <StackPanel Grid.Row="0" Spacing="8">
-                                        <TextBlock Text="Check For Updates" FontSize="13" FontWeight="SemiBold"
+                                        <TextBlock x:Uid="Settings_ComponentUpdates_CheckHeader" Text="Check For Updates" FontSize="13" FontWeight="SemiBold"
                                                    Foreground="{StaticResource TextPrimaryBrush}"/>
-                                        <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"
+                                        <TextBlock x:Uid="Settings_ComponentUpdates_CheckDescription" TextWrapping="Wrap" FontSize="11" Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"
                                                    Text="Fetches the latest manifest data and checks all components for available updates. Bypasses the 4-hour cooldown."/>
                                     </StackPanel>
-                                    <Button Grid.Row="1" x:Name="CheckForUpdatesBtn" Content="Check For Updates"
+                                    <Button Grid.Row="1" x:Name="CheckForUpdatesBtn" x:Uid="Settings_ComponentUpdates_CheckButton" Content="Check For Updates"
                                             Click="CheckForUpdatesButton_Click"
                                             Background="{StaticResource AccentBlueBgBrush}" Foreground="{StaticResource AccentBlueBrush}"
                                             BorderBrush="{StaticResource AccentBlueBorderBrush}" BorderThickness="1"
@@ -1258,16 +1291,16 @@
 
                                 <!-- Right: Automatic Updates -->
                                 <StackPanel Grid.Column="2" Spacing="8">
-                                    <TextBlock Text="Automatic Updates" FontSize="13" FontWeight="SemiBold"
+                                    <TextBlock x:Uid="Settings_ComponentUpdates_AutoHeader" Text="Automatic Updates" FontSize="13" FontWeight="SemiBold"
                                                Foreground="{StaticResource TextPrimaryBrush}"/>
-                                    <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"
+                                    <TextBlock x:Uid="Settings_ComponentUpdates_AutoDescription" TextWrapping="Wrap" FontSize="11" Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"
                                                Text="When enabled, RHI silently installs component updates in the background after each update check. Games that are running when an update is detected will be retried automatically once they close. Does not apply to app updates."/>
                                     <ComboBox x:Name="AutoUpdateComponentsCombo" x:FieldModifier="internal"
                                               FontSize="12" HorizontalAlignment="Stretch"
                                               ToolTipService.ToolTip="Automatically install ReShade, RenoDX, ReLimiter, DC, OptiScaler, RE Framework, Luma, DXVK and DOF Fix updates silently in the background"
                                               SelectionChanged="AutoUpdateComponentsCombo_SelectionChanged">
-                                        <ComboBoxItem Content="No"/>
-                                        <ComboBoxItem Content="Yes"/>
+                                        <ComboBoxItem x:Uid="Settings_ComponentUpdates_No" Content="No"/>
+                                        <ComboBoxItem x:Uid="Settings_ComponentUpdates_Yes" Content="Yes"/>
                                     </ComboBox>
                                 </StackPanel>
                             </Grid>

--- a/RenoDXCommander/MainWindow.xaml
+++ b/RenoDXCommander/MainWindow.xaml
@@ -5,6 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:vm="using:RenoDXCommander.ViewModels"
     xmlns:converters="using:RenoDXCommander.Converters"
+    xmlns:l="using:WinUI3Localizer"
     xmlns:controls="using:RenoDXCommander.Controls"
     Title="RHI">
     <Grid RequestedTheme="Dark" Background="{StaticResource SurfaceBaseBrush}" AllowDrop="True" DragOver="Grid_DragOver" Drop="Grid_Drop">
@@ -38,20 +39,20 @@
                         <TextBlock FontSize="15" FontWeight="Bold">
                             <Run Text="RHI" Foreground="{StaticResource AccentTealBrush}"/>
                         </TextBlock>
-                        <TextBlock x:Uid="App_Subtitle" Text="Simplified PC Gaming" FontSize="10" Foreground="{StaticResource AccentTealDimBrush}"/>
+                        <TextBlock l:Uids.Uid="App_Subtitle" Text="Simplified PC Gaming" FontSize="10" Foreground="{StaticResource AccentTealDimBrush}"/>
                     </StackPanel>
                 </StackPanel>
 
                 <!-- Action buttons -->
                 <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <Button x:Name="NewModsBtn" x:Uid="Toolbar_NewModsButton" Content="New Mods Available"
+                    <Button x:Name="NewModsBtn" l:Uids.Uid="Toolbar_NewModsButton" Content="New Mods Available"
                             Click="NewModsButton_Click"
                             Visibility="{x:Bind ViewModel.NewWikiModsButtonVisibility, Mode=OneWay}"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentGreenBrush}"
                             BorderBrush="{StaticResource AccentGreenBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="New RenoDX mods have been added to the wiki"/>
-                    <Button x:Name="FaqBtn" x:Uid="Toolbar_FaqButton" Content="Quick Start"
+                    <Button x:Name="FaqBtn" l:Uids.Uid="Toolbar_FaqButton" Content="Quick Start"
                             Click="FaqButton_Click"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
@@ -60,28 +61,28 @@
 
                     <Border Width="1" Height="20" Background="{StaticResource BorderSubtleBrush}" Margin="4,0"/>
 
-                    <Button x:Name="RefreshBtn" x:Uid="Toolbar_RefreshButton" Content="Refresh"
+                    <Button x:Name="RefreshBtn" l:Uids.Uid="Toolbar_RefreshButton" Content="Refresh"
                             Click="RefreshButton_Click"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Rescan game library and fetch latest mod info"/>
-                    <Button x:Name="ShadersAddonsBtn" x:Uid="Toolbar_ShadersAddonsButton" Content="Shaders/Addons"
+                    <Button x:Name="ShadersAddonsBtn" l:Uids.Uid="Toolbar_ShadersAddonsButton" Content="Shaders/Addons"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Manage global shaders and ReShade addons">
                         <Button.Flyout>
                             <MenuFlyout Placement="Bottom">
-                                <MenuFlyoutItem x:Name="ChooseShadersItem" x:Uid="Toolbar_ChooseShadersItem" Text="Global Shaders" Click="ChooseShadersButton_Click"/>
-                                <MenuFlyoutItem x:Name="ReShadeAddonsItem" x:Uid="Toolbar_ReShadeAddonsItem" Text="ReShade Addons" Click="ReShadeAddonsButton_Click"/>
+                                <MenuFlyoutItem x:Name="ChooseShadersItem" l:Uids.Uid="Toolbar_ChooseShadersItem" Text="Global Shaders" Click="ChooseShadersButton_Click"/>
+                                <MenuFlyoutItem x:Name="ReShadeAddonsItem" l:Uids.Uid="Toolbar_ReShadeAddonsItem" Text="ReShade Addons" Click="ReShadeAddonsButton_Click"/>
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>
 
                     <Border Width="1" Height="20" Background="{StaticResource BorderSubtleBrush}" Margin="4,0"/>
 
-                    <Button x:Name="UpdateBtn" x:Uid="Toolbar_UpdateButton" Content="Update All"
+                    <Button x:Name="UpdateBtn" l:Uids.Uid="Toolbar_UpdateButton" Content="Update All"
                             Click="UpdateAllButton_Click"
                             Background="{StaticResource SurfaceInputBrush}"
                             Foreground="{StaticResource TextTertiaryBrush}"
@@ -92,31 +93,31 @@
 
                     <Border Width="1" Height="20" Background="{StaticResource BorderSubtleBrush}" Margin="4,0"/>
 
-                    <Button x:Name="LinksBtn" x:Uid="Toolbar_LinksButton" Content="Links"
+                    <Button x:Name="LinksBtn" l:Uids.Uid="Toolbar_LinksButton" Content="Links"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Useful links and resources">
                         <Button.Flyout>
                             <MenuFlyout Placement="Bottom">
-                                <MenuFlyoutItem x:Uid="Toolbar_RenoDXWikiItem" Text="RenoDX Wiki" Click="LinkRenoDxWiki_Click"/>
-                                <MenuFlyoutItem x:Uid="Toolbar_LumaWikiItem" Text="Luma Wiki" Click="LinkLumaWiki_Click"/>
-                                <MenuFlyoutItem x:Uid="Toolbar_RhiGitHubItem" Text="RHI GitHub" Click="LinkRhiGithub_Click"/>
-                                <MenuFlyoutItem x:Uid="Toolbar_ReLimiterGitHubItem" Text="ReLimiter GitHub" Click="LinkReLimiterGithub_Click"/>
+                                <MenuFlyoutItem l:Uids.Uid="Toolbar_RenoDXWikiItem" Text="RenoDX Wiki" Click="LinkRenoDxWiki_Click"/>
+                                <MenuFlyoutItem l:Uids.Uid="Toolbar_LumaWikiItem" Text="Luma Wiki" Click="LinkLumaWiki_Click"/>
+                                <MenuFlyoutItem l:Uids.Uid="Toolbar_RhiGitHubItem" Text="RHI GitHub" Click="LinkRhiGithub_Click"/>
+                                <MenuFlyoutItem l:Uids.Uid="Toolbar_ReLimiterGitHubItem" Text="ReLimiter GitHub" Click="LinkReLimiterGithub_Click"/>
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>
-                    <Button x:Name="SupportBtn" x:Uid="Toolbar_SupportButton" Content="Help"
+                    <Button x:Name="SupportBtn" l:Uids.Uid="Toolbar_SupportButton" Content="Help"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Support and help resources">
                         <Button.Flyout>
                             <MenuFlyout Placement="Bottom">
-                                <MenuFlyoutItem x:Uid="Toolbar_DiscordItem" Text="Discord" Click="SupportDiscord_Click"/>
-                                <MenuFlyoutItem x:Uid="Toolbar_GuideItem" Text="Guide" Click="SupportGuide_Click"/>
-                                <MenuFlyoutItem x:Uid="Toolbar_KofiItem" Text="Ko-fi" Click="SupportKofi_Click"/>
-                                <MenuFlyoutItem x:Uid="Toolbar_AboutItem" Text="About" Click="AboutButton_Click"/>
+                                <MenuFlyoutItem l:Uids.Uid="Toolbar_DiscordItem" Text="Discord" Click="SupportDiscord_Click"/>
+                                <MenuFlyoutItem l:Uids.Uid="Toolbar_GuideItem" Text="Guide" Click="SupportGuide_Click"/>
+                                <MenuFlyoutItem l:Uids.Uid="Toolbar_KofiItem" Text="Ko-fi" Click="SupportKofi_Click"/>
+                                <MenuFlyoutItem l:Uids.Uid="Toolbar_AboutItem" Text="About" Click="AboutButton_Click"/>
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>
@@ -129,7 +130,7 @@
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
                             CornerRadius="8" Padding="12,7" FontSize="12"
                             ToolTipService.ToolTip="Toggle between Detail and Simple view"/>
-                    <Button x:Name="SettingsBtn" x:Uid="Toolbar_SettingsButton" Content="Settings"
+                    <Button x:Name="SettingsBtn" l:Uids.Uid="Toolbar_SettingsButton" Content="Settings"
                             Click="SettingsButton_Click" IsEnabled="False"
                             Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource AccentTealBrush}"
                             BorderBrush="{StaticResource AccentTealBorderBrush}" BorderThickness="1"
@@ -147,7 +148,7 @@
                         Spacing="16" Visibility="Collapsed" Canvas.ZIndex="10">
                 <ProgressRing x:Name="LoadingRing" IsActive="True" Width="48" Height="48"
                               Foreground="{StaticResource AccentBlueBrush}"/>
-                <TextBlock x:Name="LoadingTitle" x:Uid="Loading_Title" Text="Loading..." FontSize="16"
+                <TextBlock x:Name="LoadingTitle" l:Uids.Uid="Loading_Title" Text="Loading..." FontSize="16"
                            Foreground="{StaticResource ChipTextBrush}" HorizontalAlignment="Center"/>
                 <TextBlock x:Name="LoadingSubtitle" Text="" FontSize="12"
                            Foreground="{StaticResource TextDisabledBrush}" HorizontalAlignment="Center"/>
@@ -178,14 +179,14 @@
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBox x:Name="SearchBox" Grid.Column="0" x:Uid="Sidebar_SearchBox"
+                                <TextBox x:Name="SearchBox" Grid.Column="0" l:Uids.Uid="Sidebar_SearchBox"
                                          PlaceholderText="Filter games..."
                                          TextChanged="SearchBox_TextChanged"
                                          Background="{StaticResource SurfaceInputBrush}" Foreground="{StaticResource TextSecondaryBrush}"
                                          BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
                                          CornerRadius="8" Padding="10,7"
                                          FontSize="12"/>
-                                <Button x:Name="SaveFilterButton" Grid.Column="1" x:Uid="Sidebar_SaveFilterButton"
+                                <Button x:Name="SaveFilterButton" Grid.Column="1" l:Uids.Uid="Sidebar_SaveFilterButton"
                                         Content="+"
                                         Click="SaveFilterButton_Click"
                                         Visibility="Collapsed"
@@ -198,7 +199,7 @@
                                         FontSize="14" FontWeight="Bold"
                                         VerticalAlignment="Center"
                                         ToolTipService.ToolTip="Save current search as a custom filter"/>
-                                <Button x:Name="AddGameBtn" Grid.Column="2" x:Uid="Sidebar_AddGameButton"
+                                <Button x:Name="AddGameBtn" Grid.Column="2" l:Uids.Uid="Sidebar_AddGameButton"
                                         Content="+"
                                         Click="AddGameButton_Click"
                                         Background="{StaticResource AccentGreenBgBrush}"
@@ -218,33 +219,33 @@
                                 BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
                             <StackPanel Spacing="4">
                                 <StackPanel Orientation="Horizontal" Spacing="4">
-                                    <Button x:Name="FilterDetected" x:Uid="Sidebar_FilterDetected" Content="All Games" Tag="Detected"
+                                    <Button x:Name="FilterDetected" l:Uids.Uid="Sidebar_FilterDetected" Content="All Games" Tag="Detected"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipActiveBrush}" Foreground="White"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterInstalled" x:Uid="Sidebar_FilterInstalled" Content="Installed" Tag="Installed"
+                                    <Button x:Name="FilterInstalled" l:Uids.Uid="Sidebar_FilterInstalled" Content="Installed" Tag="Installed"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterFavourites" x:Uid="Sidebar_FilterFavourites" Content="Favourites" Tag="Favourites"
+                                    <Button x:Name="FilterFavourites" l:Uids.Uid="Sidebar_FilterFavourites" Content="Favourites" Tag="Favourites"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterHidden" x:Uid="Sidebar_FilterHidden" Content="Hidden" Tag="Hidden"
+                                    <Button x:Name="FilterHidden" l:Uids.Uid="Sidebar_FilterHidden" Content="Hidden" Tag="Hidden"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Spacing="4">
-                                    <Button x:Name="FilterUnreal" x:Uid="Sidebar_FilterUnreal" Content="Unreal" Tag="Unreal"
+                                    <Button x:Name="FilterUnreal" l:Uids.Uid="Sidebar_FilterUnreal" Content="Unreal" Tag="Unreal"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterUnity" x:Uid="Sidebar_FilterUnity" Content="Unity" Tag="Unity"
+                                    <Button x:Name="FilterUnity" l:Uids.Uid="Sidebar_FilterUnity" Content="Unity" Tag="Unity"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
-                                    <Button x:Name="FilterOther" x:Uid="Sidebar_FilterOther" Content="Other" Tag="Other"
+                                    <Button x:Name="FilterOther" l:Uids.Uid="Sidebar_FilterOther" Content="Other" Tag="Other"
                                             Click="Filter_Click"
                                             Background="{StaticResource ChipDefaultBrush}" Foreground="{StaticResource ChipTextBrush}"
                                             BorderThickness="0" CornerRadius="7" Padding="10,5" FontSize="11"/>
@@ -1200,12 +1201,12 @@
                 <Border Grid.Row="0" Padding="24,12,24,10" Background="Transparent"
                         BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
                     <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                        <Button x:Name="SettingsBackBtn" x:Uid="Settings_BackButton" Content="← Back to Games"
+                        <Button x:Name="SettingsBackBtn" l:Uids.Uid="Settings_BackButton" Content="← Back to Games"
                                 Click="SettingsBack_Click"
                                 Background="{StaticResource SurfaceOverlayBrush}" Foreground="{StaticResource TextSecondaryBrush}"
                                 BorderBrush="{StaticResource BorderDefaultBrush}" BorderThickness="1"
                                 CornerRadius="8" Padding="12,6" FontSize="12"/>
-                        <TextBlock x:Uid="Settings_Title" Text="Settings" FontSize="20" FontWeight="Bold"
+                        <TextBlock l:Uids.Uid="Settings_Title" Text="Settings" FontSize="20" FontWeight="Bold"
                                    Foreground="{StaticResource TextPrimaryBrush}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Border>
@@ -1221,9 +1222,9 @@
                         <Border Background="{StaticResource SurfaceRaisedBrush}" CornerRadius="10" Padding="20,16"
                                 BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1">
                             <StackPanel Spacing="8">
-                                <TextBlock x:Uid="Settings_Language_Title" Text="Language" FontSize="15" FontWeight="Bold"
+                                <TextBlock l:Uids.Uid="Settings_Language_Title" Text="Language" FontSize="15" FontWeight="Bold"
                                            Foreground="{StaticResource TextPrimaryBrush}"/>
-                                <TextBlock x:Uid="Settings_Language_Description" Text="Choose the interface language. New languages can be added as additional resource files."
+                                <TextBlock l:Uids.Uid="Settings_Language_Description" Text="Choose the interface language. New languages can be added as additional resource files."
                                            TextWrapping="Wrap" FontSize="11"
                                            Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"/>
                                 <Grid ColumnSpacing="8">
@@ -1231,18 +1232,18 @@
                                         <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" x:Uid="Settings_Language_Label" Text="Interface language" FontSize="12"
+                                    <TextBlock Grid.Column="0" l:Uids.Uid="Settings_Language_Label" Text="Interface language" FontSize="12"
                                                Foreground="{StaticResource TextSecondaryBrush}"
                                                VerticalAlignment="Center"/>
                                     <ComboBox Grid.Column="1" x:Name="UiLanguageCombo" x:FieldModifier="internal"
                                               SelectionChanged="UiLanguageCombo_SelectionChanged"
                                               FontSize="12" HorizontalAlignment="Stretch">
-                                        <ComboBoxItem x:Uid="Settings_Language_Auto" Content="Follow system" Tag="auto"/>
-                                        <ComboBoxItem x:Uid="Settings_Language_English" Content="English (United States)" Tag="en-US"/>
-                                        <ComboBoxItem x:Uid="Settings_Language_SimplifiedChinese" Content="Simplified Chinese" Tag="zh-CN"/>
+                                        <ComboBoxItem l:Uids.Uid="Settings_Language_Auto" Content="Follow system" Tag="auto"/>
+                                        <ComboBoxItem l:Uids.Uid="Settings_Language_English" Content="English (United States)" Tag="en-US"/>
+                                        <ComboBoxItem l:Uids.Uid="Settings_Language_SimplifiedChinese" Content="Simplified Chinese" Tag="zh-CN"/>
                                     </ComboBox>
                                 </Grid>
-                                <TextBlock x:Uid="Settings_Language_RestartNote" Text="Language changes take effect after restarting RHI."
+                                <TextBlock l:Uids.Uid="Settings_Language_RestartNote" Text="Language changes take effect after restarting RHI."
                                            TextWrapping="Wrap" FontSize="11"
                                            Foreground="{StaticResource TextTertiaryBrush}"/>
                             </StackPanel>
@@ -1254,7 +1255,7 @@
                         <Border Background="{StaticResource SurfaceRaisedBrush}" CornerRadius="10" Padding="20,16"
                                 BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1">
                             <StackPanel Spacing="12">
-                            <TextBlock x:Uid="Settings_ComponentUpdates_Title" Text="Component Updates" FontSize="15" FontWeight="Bold"
+                            <TextBlock l:Uids.Uid="Settings_ComponentUpdates_Title" Text="Component Updates" FontSize="15" FontWeight="Bold"
                                        Foreground="{StaticResource TextPrimaryBrush}"/>
                             <Grid ColumnSpacing="0" RowSpacing="8">
                                 <Grid.ColumnDefinitions>
@@ -1270,12 +1271,12 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <StackPanel Grid.Row="0" Spacing="8">
-                                        <TextBlock x:Uid="Settings_ComponentUpdates_CheckHeader" Text="Check For Updates" FontSize="13" FontWeight="SemiBold"
+                                        <TextBlock l:Uids.Uid="Settings_ComponentUpdates_CheckHeader" Text="Check For Updates" FontSize="13" FontWeight="SemiBold"
                                                    Foreground="{StaticResource TextPrimaryBrush}"/>
-                                        <TextBlock x:Uid="Settings_ComponentUpdates_CheckDescription" TextWrapping="Wrap" FontSize="11" Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"
+                                        <TextBlock l:Uids.Uid="Settings_ComponentUpdates_CheckDescription" TextWrapping="Wrap" FontSize="11" Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"
                                                    Text="Fetches the latest manifest data and checks all components for available updates. Bypasses the 4-hour cooldown."/>
                                     </StackPanel>
-                                    <Button Grid.Row="1" x:Name="CheckForUpdatesBtn" x:Uid="Settings_ComponentUpdates_CheckButton" Content="Check For Updates"
+                                    <Button Grid.Row="1" x:Name="CheckForUpdatesBtn" l:Uids.Uid="Settings_ComponentUpdates_CheckButton" Content="Check For Updates"
                                             Click="CheckForUpdatesButton_Click"
                                             Background="{StaticResource AccentBlueBgBrush}" Foreground="{StaticResource AccentBlueBrush}"
                                             BorderBrush="{StaticResource AccentBlueBorderBrush}" BorderThickness="1"
@@ -1291,16 +1292,16 @@
 
                                 <!-- Right: Automatic Updates -->
                                 <StackPanel Grid.Column="2" Spacing="8">
-                                    <TextBlock x:Uid="Settings_ComponentUpdates_AutoHeader" Text="Automatic Updates" FontSize="13" FontWeight="SemiBold"
+                                    <TextBlock l:Uids.Uid="Settings_ComponentUpdates_AutoHeader" Text="Automatic Updates" FontSize="13" FontWeight="SemiBold"
                                                Foreground="{StaticResource TextPrimaryBrush}"/>
-                                    <TextBlock x:Uid="Settings_ComponentUpdates_AutoDescription" TextWrapping="Wrap" FontSize="11" Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"
+                                    <TextBlock l:Uids.Uid="Settings_ComponentUpdates_AutoDescription" TextWrapping="Wrap" FontSize="11" Foreground="{StaticResource InlineDescriptionBrush}" LineHeight="18"
                                                Text="When enabled, RHI silently installs component updates in the background after each update check. Games that are running when an update is detected will be retried automatically once they close. Does not apply to app updates."/>
                                     <ComboBox x:Name="AutoUpdateComponentsCombo" x:FieldModifier="internal"
                                               FontSize="12" HorizontalAlignment="Stretch"
                                               ToolTipService.ToolTip="Automatically install ReShade, RenoDX, ReLimiter, DC, OptiScaler, RE Framework, Luma, DXVK and DOF Fix updates silently in the background"
                                               SelectionChanged="AutoUpdateComponentsCombo_SelectionChanged">
-                                        <ComboBoxItem x:Uid="Settings_ComponentUpdates_No" Content="No"/>
-                                        <ComboBoxItem x:Uid="Settings_ComponentUpdates_Yes" Content="Yes"/>
+                                        <ComboBoxItem l:Uids.Uid="Settings_ComponentUpdates_No" Content="No"/>
+                                        <ComboBoxItem l:Uids.Uid="Settings_ComponentUpdates_Yes" Content="Yes"/>
                                     </ComboBox>
                                 </StackPanel>
                             </Grid>

--- a/RenoDXCommander/RenoDXCommander.csproj
+++ b/RenoDXCommander/RenoDXCommander.csproj
@@ -30,6 +30,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Strings\**\*.resw">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Remove="Assets\manifest.json" />
     <!-- Exclude backup files from XAML compilation -->
     <None Remove="original\**" />
@@ -169,5 +176,6 @@
     <PackageReference Include="CommunityToolkit.Labs.WinUI.Controls.MarkdownTextBlock" Version="0.1.251217-build.2433" />
     <PackageReference Include="NvAPIWrapper.Net" Version="0.8.1.101" />
     <PackageReference Include="SharpCompress" Version="0.37.2" />
+    <PackageReference Include="WinUI3Localizer" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/RenoDXCommander/Services/LocalizationService.cs
+++ b/RenoDXCommander/Services/LocalizationService.cs
@@ -1,0 +1,56 @@
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace RenoDXCommander.Services;
+
+public static class UiLanguage
+{
+    public const string Auto = "auto";
+    public const string English = "en-US";
+    public const string SimplifiedChinese = "zh-CN";
+
+    public static readonly IReadOnlyList<string> SupportedLanguages =
+    [
+        English,
+        SimplifiedChinese,
+    ];
+
+    public static string Normalize(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+            return Auto;
+
+        return language.Trim().ToLowerInvariant() switch
+        {
+            "auto" or "" => Auto,
+            "en" or "english" or "en-us" => English,
+            "zh" or "zh-hans" or "zh-cn" or "simplified chinese" => SimplifiedChinese,
+            _ => language.Trim(),
+        };
+    }
+
+    public static void Apply(string? language)
+    {
+        var normalized = Normalize(language);
+        Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride =
+            normalized == Auto ? string.Empty : normalized;
+    }
+}
+
+public static class LocalizationService
+{
+    private static ResourceLoader? _resourceLoader;
+
+    public static string GetString(string key, string fallback = "")
+    {
+        try
+        {
+            _resourceLoader ??= new ResourceLoader();
+            var value = _resourceLoader.GetString(key);
+            return string.IsNullOrWhiteSpace(value) ? fallback : value;
+        }
+        catch
+        {
+            return fallback;
+        }
+    }
+}

--- a/RenoDXCommander/Services/LocalizationService.cs
+++ b/RenoDXCommander/Services/LocalizationService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Windows.ApplicationModel.Resources;
+using WinUI3Localizer;
 
 namespace RenoDXCommander.Services;
 
@@ -28,24 +28,55 @@ public static class UiLanguage
         };
     }
 
-    public static void Apply(string? language)
+    public static string Resolve(string? language)
     {
         var normalized = Normalize(language);
-        Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride =
-            normalized == Auto ? string.Empty : normalized;
+        if (normalized != Auto)
+            return normalized;
+
+        var uiCulture = System.Globalization.CultureInfo.CurrentUICulture;
+        if (string.Equals(uiCulture.TwoLetterISOLanguageName, "zh", StringComparison.OrdinalIgnoreCase) &&
+            (string.Equals(uiCulture.Name, "zh-CN", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(uiCulture.Name, "zh-Hans", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(uiCulture.Name, "zh-Hans-CN", StringComparison.OrdinalIgnoreCase)))
+        {
+            return SimplifiedChinese;
+        }
+
+        return English;
     }
 }
 
 public static class LocalizationService
 {
-    private static ResourceLoader? _resourceLoader;
+    public static string StringsFolderPath { get; private set; } =
+        System.IO.Path.Combine(GetExecutableDirectory(), "Strings");
+
+    private static string GetExecutableDirectory() =>
+        System.IO.Path.GetDirectoryName(Environment.ProcessPath) ?? AppContext.BaseDirectory;
+
+    public static async Task<bool> InitializeAsync(string? language)
+    {
+        try
+        {
+            _ = await new LocalizerBuilder()
+                .AddStringResourcesFolderForLanguageDictionaries(StringsFolderPath, ignoreExceptions: true)
+                .SetOptions(options => options.DefaultLanguage = UiLanguage.Resolve(language))
+                .Build();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            CrashReporter.WriteCrashReport("LocalizationService.InitializeAsync", ex);
+            return false;
+        }
+    }
 
     public static string GetString(string key, string fallback = "")
     {
         try
         {
-            _resourceLoader ??= new ResourceLoader();
-            var value = _resourceLoader.GetString(key);
+            var value = Localizer.Get().GetLocalizedString(key);
             return string.IsNullOrWhiteSpace(value) ? fallback : value;
         }
         catch

--- a/RenoDXCommander/SettingsHandler.cs
+++ b/RenoDXCommander/SettingsHandler.cs
@@ -28,6 +28,7 @@ public class SettingsHandler
     internal string _currentUlHotkeyString = "F12";
     internal string _currentOsHotkeyString = "Insert";
     internal string _currentScreenshotHotkeyString = "44,0,0,0";
+    private bool _uiLanguageComboInitializing;
 
     public SettingsHandler(MainWindow window)
     {
@@ -39,6 +40,31 @@ public class SettingsHandler
 
     private MainViewModel ViewModel => _window.ViewModel;
 
+    private void InitializeUiLanguageCombo()
+    {
+        _uiLanguageComboInitializing = true;
+        var language = ViewModel.Settings.UiLanguage;
+        _window.UiLanguageCombo.SelectedIndex = language switch
+        {
+            UiLanguage.English => 1,
+            UiLanguage.SimplifiedChinese => 2,
+            _ => 0,
+        };
+        _uiLanguageComboInitializing = false;
+    }
+
+    public void UiLanguageCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_uiLanguageComboInitializing) return;
+
+        var selected = ((sender as ComboBox)?.SelectedItem as ComboBoxItem)?.Tag as string;
+        if (string.IsNullOrWhiteSpace(selected)) return;
+
+        ViewModel.Settings.UiLanguage = UiLanguage.Normalize(selected);
+        UiLanguage.Apply(ViewModel.Settings.UiLanguage);
+        ViewModel.SaveSettingsPublic();
+    }
+
     public void SettingsButton_Click(object sender, RoutedEventArgs e)
     {
         ViewModel.NavigateToSettingsCommand.Execute(null);
@@ -48,6 +74,7 @@ public class SettingsHandler
         // Sync toggle state with ViewModel
         _window.CustomShadersCombo.SelectedIndex = ViewModel.Settings.GlobalShadersOff ? 0 : (ViewModel.Settings.UseCustomShaders ? 2 : 1);
         _window.AboutVersionText.Text = $"v{CrashReporter.AppVersion}  ·  Simplified PC Gaming by RankFTW";
+        InitializeUiLanguageCombo();
         // Populate addon watch folder textbox
         _window.AddonWatchFolderBox.Text = ViewModel.Settings.AddonWatchFolder;
         // Populate screenshot path and per-game combo

--- a/RenoDXCommander/SettingsHandler.cs
+++ b/RenoDXCommander/SettingsHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 using RenoDXCommander.Models;
 using RenoDXCommander.Services;
 using RenoDXCommander.ViewModels;
+using WinUI3Localizer;
 
 namespace RenoDXCommander;
 
@@ -53,7 +54,7 @@ public class SettingsHandler
         _uiLanguageComboInitializing = false;
     }
 
-    public void UiLanguageCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    public async void UiLanguageCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_uiLanguageComboInitializing) return;
 
@@ -61,8 +62,15 @@ public class SettingsHandler
         if (string.IsNullOrWhiteSpace(selected)) return;
 
         ViewModel.Settings.UiLanguage = UiLanguage.Normalize(selected);
-        UiLanguage.Apply(ViewModel.Settings.UiLanguage);
         ViewModel.SaveSettingsPublic();
+        try
+        {
+            await Localizer.Get().SetLanguage(UiLanguage.Resolve(ViewModel.Settings.UiLanguage));
+        }
+        catch (Exception ex)
+        {
+            CrashReporter.WriteCrashReport("SettingsHandler.UiLanguageCombo_SelectionChanged", ex);
+        }
     }
 
     public void SettingsButton_Click(object sender, RoutedEventArgs e)

--- a/RenoDXCommander/Strings/en-US/Resources.resw
+++ b/RenoDXCommander/Strings/en-US/Resources.resw
@@ -45,7 +45,7 @@
   <data name="Settings_Language_Auto.Content" xml:space="preserve"><value>Follow system</value></data>
   <data name="Settings_Language_English.Content" xml:space="preserve"><value>English (United States)</value></data>
   <data name="Settings_Language_SimplifiedChinese.Content" xml:space="preserve"><value>Simplified Chinese</value></data>
-  <data name="Settings_Language_RestartNote.Text" xml:space="preserve"><value>Language changes take effect after restarting RHI.</value></data>
+  <data name="Settings_Language_RestartNote.Text" xml:space="preserve"><value>Language changes apply immediately.</value></data>
   <data name="Settings_ComponentUpdates_Title.Text" xml:space="preserve"><value>Component Updates</value></data>
   <data name="Settings_ComponentUpdates_CheckHeader.Text" xml:space="preserve"><value>Check For Updates</value></data>
   <data name="Settings_ComponentUpdates_CheckDescription.Text" xml:space="preserve"><value>Fetches the latest manifest data and checks all components for available updates. Bypasses the 4-hour cooldown.</value></data>

--- a/RenoDXCommander/Strings/en-US/Resources.resw
+++ b/RenoDXCommander/Strings/en-US/Resources.resw
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="App_Subtitle.Text" xml:space="preserve"><value>Simplified PC Gaming</value></data>
+  <data name="Toolbar_NewModsButton.Content" xml:space="preserve"><value>New Mods Available</value></data>
+  <data name="Toolbar_NewModsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>New RenoDX mods have been added to the wiki</value></data>
+  <data name="Toolbar_FaqButton.Content" xml:space="preserve"><value>Quick Start</value></data>
+  <data name="Toolbar_FaqButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Quick Start Guide</value></data>
+  <data name="Toolbar_RefreshButton.Content" xml:space="preserve"><value>Refresh</value></data>
+  <data name="Toolbar_RefreshButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Rescan game library and fetch latest mod info</value></data>
+  <data name="Toolbar_ShadersAddonsButton.Content" xml:space="preserve"><value>Shaders/Addons</value></data>
+  <data name="Toolbar_ShadersAddonsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Manage global shaders and ReShade addons</value></data>
+  <data name="Toolbar_ChooseShadersItem.Text" xml:space="preserve"><value>Global Shaders</value></data>
+  <data name="Toolbar_ReShadeAddonsItem.Text" xml:space="preserve"><value>ReShade Addons</value></data>
+  <data name="Toolbar_UpdateButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Update components</value></data>
+  <data name="Toolbar_LinksButton.Content" xml:space="preserve"><value>Links</value></data>
+  <data name="Toolbar_LinksButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Useful links and resources</value></data>
+  <data name="Toolbar_RenoDXWikiItem.Text" xml:space="preserve"><value>RenoDX Wiki</value></data>
+  <data name="Toolbar_LumaWikiItem.Text" xml:space="preserve"><value>Luma Wiki</value></data>
+  <data name="Toolbar_RhiGitHubItem.Text" xml:space="preserve"><value>RHI GitHub</value></data>
+  <data name="Toolbar_ReLimiterGitHubItem.Text" xml:space="preserve"><value>ReLimiter GitHub</value></data>
+  <data name="Toolbar_SupportButton.Content" xml:space="preserve"><value>Help</value></data>
+  <data name="Toolbar_SupportButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Support and help resources</value></data>
+  <data name="Toolbar_DiscordItem.Text" xml:space="preserve"><value>Discord</value></data>
+  <data name="Toolbar_GuideItem.Text" xml:space="preserve"><value>Guide</value></data>
+  <data name="Toolbar_KofiItem.Text" xml:space="preserve"><value>Ko-fi</value></data>
+  <data name="Toolbar_AboutItem.Text" xml:space="preserve"><value>About</value></data>
+  <data name="Toolbar_SettingsButton.Content" xml:space="preserve"><value>Settings</value></data>
+  <data name="Toolbar_SettingsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Open settings</value></data>
+  <data name="Loading_Title.Text" xml:space="preserve"><value>Loading...</value></data>
+  <data name="Sidebar_SearchBox.PlaceholderText" xml:space="preserve"><value>Filter games...</value></data>
+  <data name="Sidebar_SaveFilterButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Save current search as a custom filter</value></data>
+  <data name="Sidebar_AddGameButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Manually add a game</value></data>
+  <data name="Sidebar_FilterDetected.Content" xml:space="preserve"><value>All Games</value></data>
+  <data name="Sidebar_FilterInstalled.Content" xml:space="preserve"><value>Installed</value></data>
+  <data name="Sidebar_FilterFavourites.Content" xml:space="preserve"><value>Favourites</value></data>
+  <data name="Sidebar_FilterHidden.Content" xml:space="preserve"><value>Hidden</value></data>
+  <data name="Sidebar_FilterUnreal.Content" xml:space="preserve"><value>Unreal</value></data>
+  <data name="Sidebar_FilterUnity.Content" xml:space="preserve"><value>Unity</value></data>
+  <data name="Sidebar_FilterOther.Content" xml:space="preserve"><value>Other</value></data>
+  <data name="Settings_BackButton.Content" xml:space="preserve"><value>&#8592; Back to Games</value></data>
+  <data name="Settings_Title.Text" xml:space="preserve"><value>Settings</value></data>
+  <data name="Settings_Language_Title.Text" xml:space="preserve"><value>Language</value></data>
+  <data name="Settings_Language_Description.Text" xml:space="preserve"><value>Choose the interface language. New languages can be added as additional resource files.</value></data>
+  <data name="Settings_Language_Label.Text" xml:space="preserve"><value>Interface language</value></data>
+  <data name="Settings_Language_Auto.Content" xml:space="preserve"><value>Follow system</value></data>
+  <data name="Settings_Language_English.Content" xml:space="preserve"><value>English (United States)</value></data>
+  <data name="Settings_Language_SimplifiedChinese.Content" xml:space="preserve"><value>Simplified Chinese</value></data>
+  <data name="Settings_Language_RestartNote.Text" xml:space="preserve"><value>Language changes take effect after restarting RHI.</value></data>
+  <data name="Settings_ComponentUpdates_Title.Text" xml:space="preserve"><value>Component Updates</value></data>
+  <data name="Settings_ComponentUpdates_CheckHeader.Text" xml:space="preserve"><value>Check For Updates</value></data>
+  <data name="Settings_ComponentUpdates_CheckDescription.Text" xml:space="preserve"><value>Fetches the latest manifest data and checks all components for available updates. Bypasses the 4-hour cooldown.</value></data>
+  <data name="Settings_ComponentUpdates_CheckButton.Content" xml:space="preserve"><value>Check For Updates</value></data>
+  <data name="Settings_ComponentUpdates_CheckButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Check all components and the app for available updates</value></data>
+  <data name="Settings_ComponentUpdates_AutoHeader.Text" xml:space="preserve"><value>Automatic Updates</value></data>
+  <data name="Settings_ComponentUpdates_AutoDescription.Text" xml:space="preserve"><value>When enabled, RHI silently installs component updates in the background after each update check. Games that are running when an update is detected will be retried automatically once they close. Does not apply to app updates.</value></data>
+  <data name="Settings_ComponentUpdates_No.Content" xml:space="preserve"><value>No</value></data>
+  <data name="Settings_ComponentUpdates_Yes.Content" xml:space="preserve"><value>Yes</value></data>
+</root>

--- a/RenoDXCommander/Strings/zh-CN/Resources.resw
+++ b/RenoDXCommander/Strings/zh-CN/Resources.resw
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="App_Subtitle.Text" xml:space="preserve"><value>简化 PC 游戏管理</value></data>
+  <data name="Toolbar_NewModsButton.Content" xml:space="preserve"><value>新模组可用</value></data>
+  <data name="Toolbar_NewModsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Wiki 中已新增 RenoDX 模组</value></data>
+  <data name="Toolbar_FaqButton.Content" xml:space="preserve"><value>快速开始</value></data>
+  <data name="Toolbar_FaqButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>快速开始指南</value></data>
+  <data name="Toolbar_RefreshButton.Content" xml:space="preserve"><value>刷新</value></data>
+  <data name="Toolbar_RefreshButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>重新扫描游戏库并获取最新模组信息</value></data>
+  <data name="Toolbar_ShadersAddonsButton.Content" xml:space="preserve"><value>着色器/插件</value></data>
+  <data name="Toolbar_ShadersAddonsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>管理全局着色器和 ReShade 插件</value></data>
+  <data name="Toolbar_ChooseShadersItem.Text" xml:space="preserve"><value>全局着色器</value></data>
+  <data name="Toolbar_ReShadeAddonsItem.Text" xml:space="preserve"><value>ReShade 插件</value></data>
+  <data name="Toolbar_UpdateButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>更新组件</value></data>
+  <data name="Toolbar_LinksButton.Content" xml:space="preserve"><value>链接</value></data>
+  <data name="Toolbar_LinksButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>常用链接与资源</value></data>
+  <data name="Toolbar_RenoDXWikiItem.Text" xml:space="preserve"><value>RenoDX Wiki</value></data>
+  <data name="Toolbar_LumaWikiItem.Text" xml:space="preserve"><value>Luma Wiki</value></data>
+  <data name="Toolbar_RhiGitHubItem.Text" xml:space="preserve"><value>RHI GitHub</value></data>
+  <data name="Toolbar_ReLimiterGitHubItem.Text" xml:space="preserve"><value>ReLimiter GitHub</value></data>
+  <data name="Toolbar_SupportButton.Content" xml:space="preserve"><value>帮助</value></data>
+  <data name="Toolbar_SupportButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>支持与帮助资源</value></data>
+  <data name="Toolbar_DiscordItem.Text" xml:space="preserve"><value>Discord</value></data>
+  <data name="Toolbar_GuideItem.Text" xml:space="preserve"><value>指南</value></data>
+  <data name="Toolbar_KofiItem.Text" xml:space="preserve"><value>Ko-fi</value></data>
+  <data name="Toolbar_AboutItem.Text" xml:space="preserve"><value>关于</value></data>
+  <data name="Toolbar_SettingsButton.Content" xml:space="preserve"><value>设置</value></data>
+  <data name="Toolbar_SettingsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>打开设置</value></data>
+  <data name="Loading_Title.Text" xml:space="preserve"><value>正在加载...</value></data>
+  <data name="Sidebar_SearchBox.PlaceholderText" xml:space="preserve"><value>筛选游戏...</value></data>
+  <data name="Sidebar_SaveFilterButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>将当前搜索保存为自定义筛选器</value></data>
+  <data name="Sidebar_AddGameButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>手动添加游戏</value></data>
+  <data name="Sidebar_FilterDetected.Content" xml:space="preserve"><value>全部游戏</value></data>
+  <data name="Sidebar_FilterInstalled.Content" xml:space="preserve"><value>已安装</value></data>
+  <data name="Sidebar_FilterFavourites.Content" xml:space="preserve"><value>收藏</value></data>
+  <data name="Sidebar_FilterHidden.Content" xml:space="preserve"><value>已隐藏</value></data>
+  <data name="Sidebar_FilterUnreal.Content" xml:space="preserve"><value>Unreal</value></data>
+  <data name="Sidebar_FilterUnity.Content" xml:space="preserve"><value>Unity</value></data>
+  <data name="Sidebar_FilterOther.Content" xml:space="preserve"><value>其他</value></data>
+  <data name="Settings_BackButton.Content" xml:space="preserve"><value>&#8592; 返回游戏</value></data>
+  <data name="Settings_Title.Text" xml:space="preserve"><value>设置</value></data>
+  <data name="Settings_Language_Title.Text" xml:space="preserve"><value>语言</value></data>
+  <data name="Settings_Language_Description.Text" xml:space="preserve"><value>选择界面语言。后续可通过新增资源文件扩展更多语言。</value></data>
+  <data name="Settings_Language_Label.Text" xml:space="preserve"><value>界面语言</value></data>
+  <data name="Settings_Language_Auto.Content" xml:space="preserve"><value>跟随系统</value></data>
+  <data name="Settings_Language_English.Content" xml:space="preserve"><value>English (United States)</value></data>
+  <data name="Settings_Language_SimplifiedChinese.Content" xml:space="preserve"><value>简体中文</value></data>
+  <data name="Settings_Language_RestartNote.Text" xml:space="preserve"><value>语言更改将在重启 RHI 后生效。</value></data>
+  <data name="Settings_ComponentUpdates_Title.Text" xml:space="preserve"><value>组件更新</value></data>
+  <data name="Settings_ComponentUpdates_CheckHeader.Text" xml:space="preserve"><value>检查更新</value></data>
+  <data name="Settings_ComponentUpdates_CheckDescription.Text" xml:space="preserve"><value>获取最新清单数据，并检查所有组件的可用更新。此操作会跳过 4 小时冷却时间。</value></data>
+  <data name="Settings_ComponentUpdates_CheckButton.Content" xml:space="preserve"><value>检查更新</value></data>
+  <data name="Settings_ComponentUpdates_CheckButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>检查所有组件和应用是否有可用更新</value></data>
+  <data name="Settings_ComponentUpdates_AutoHeader.Text" xml:space="preserve"><value>自动更新</value></data>
+  <data name="Settings_ComponentUpdates_AutoDescription.Text" xml:space="preserve"><value>启用后，RHI 会在每次检查更新后自动在后台安装组件更新。若发现更新时游戏正在运行，会在游戏关闭后自动重试。此设置不适用于应用自身更新。</value></data>
+  <data name="Settings_ComponentUpdates_No.Content" xml:space="preserve"><value>否</value></data>
+  <data name="Settings_ComponentUpdates_Yes.Content" xml:space="preserve"><value>是</value></data>
+</root>

--- a/RenoDXCommander/Strings/zh-CN/Resources.resw
+++ b/RenoDXCommander/Strings/zh-CN/Resources.resw
@@ -45,7 +45,7 @@
   <data name="Settings_Language_Auto.Content" xml:space="preserve"><value>跟随系统</value></data>
   <data name="Settings_Language_English.Content" xml:space="preserve"><value>English (United States)</value></data>
   <data name="Settings_Language_SimplifiedChinese.Content" xml:space="preserve"><value>简体中文</value></data>
-  <data name="Settings_Language_RestartNote.Text" xml:space="preserve"><value>语言更改将在重启 RHI 后生效。</value></data>
+  <data name="Settings_Language_RestartNote.Text" xml:space="preserve"><value>语言更改会立即生效。</value></data>
   <data name="Settings_ComponentUpdates_Title.Text" xml:space="preserve"><value>组件更新</value></data>
   <data name="Settings_ComponentUpdates_CheckHeader.Text" xml:space="preserve"><value>检查更新</value></data>
   <data name="Settings_ComponentUpdates_CheckDescription.Text" xml:space="preserve"><value>获取最新清单数据，并检查所有组件的可用更新。此操作会跳过 4 小时冷却时间。</value></data>

--- a/RenoDXCommander/ViewModels/SettingsViewModel.cs
+++ b/RenoDXCommander/ViewModels/SettingsViewModel.cs
@@ -76,6 +76,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private string _resolutionTarget = "";
     [ObservableProperty] private List<uint> _resTargetDisplays = new();
     [ObservableProperty] private bool _dropHelperEnabled = true;
+    [ObservableProperty] private string _uiLanguage = Services.UiLanguage.Auto;
     [ObservableProperty] private bool _closeToTray;
     [ObservableProperty] private bool _recentGamesMenu;
     [ObservableProperty] private bool _startWithWindows;
@@ -307,6 +308,7 @@ public partial class SettingsViewModel : ObservableObject
             catch { ResTargetDisplays = new(); }
         }
         if (s.TryGetValue("DropHelperEnabled", out var dheVal)) DropHelperEnabled = dheVal != "false"; // default true
+        if (s.TryGetValue("UiLanguage", out var uiLanguageVal)) UiLanguage = Services.UiLanguage.Normalize(uiLanguageVal);
         if (s.TryGetValue("CloseToTray", out var cttVal)) CloseToTray = cttVal == "true";
         if (s.TryGetValue("RecentGamesMenu", out var rgmVal)) RecentGamesMenu = rgmVal == "true";
         if (s.TryGetValue("StartWithWindows", out var swwVal)) StartWithWindows = swwVal == "true";
@@ -406,6 +408,7 @@ public partial class SettingsViewModel : ObservableObject
         if (ResTargetDisplays.Count > 0) s["ResTargetDisplays"] = System.Text.Json.JsonSerializer.Serialize(ResTargetDisplays);
         if (!DropHelperEnabled) s["DropHelperEnabled"] = "false";
         else s["DropHelperEnabled"] = "true";
+        s["UiLanguage"] = Services.UiLanguage.Normalize(UiLanguage);
         s["CloseToTray"] = CloseToTray ? "true" : "false";
         s["RecentGamesMenu"] = RecentGamesMenu ? "true" : "false";
         s["StartWithWindows"] = StartWithWindows ? "true" : "false";


### PR DESCRIPTION
## Summary
- add a reusable multilingual UI layer for WinUI 3, with localized resources and runtime language switching
- include `en-US` as the default/fallback language and add `zh-CN` as the first translated language
- extend future language support by adding another `Strings/<locale>/Resources.resw` and registering the locale in `UiLanguage`
- add an installer language selection page and persist the installer-selected language as a machine default
- preserve existing user language preferences during upgrades
- avoid unsupported language overrides in unpackaged WinUI 3 apps
- fix overwrite upgrades leaving a shutdown signal that made the newly installed app exit immediately
- remove machine-specific paths from the Inno Setup script and use repository-relative publish output

Closes #5  
Related to #25 — this PR delivers the shared multilingual foundation and Simplified Chinese; Traditional Chinese can be added later as another locale without changing the framework.

## User-visible behavior
- the installer can display in English or Simplified Chinese
- the app can use English or Simplified Chinese from startup
- users can change language from Settings without editing configuration files
- localized strings cover the main toolbar, sidebar filters, loading text, language card, and first settings cards
- future translations do not require forking the UI logic; they only require new locale resources and locale registration

## Testing
- x64 Release publish succeeded
- resource keys checked for all 47 localized UIDs in both languages
- x64 unit tests passed: 41/41
- Inno Setup 6.7.3 package build succeeded
- clean and overwrite installations tested locally; RHI stayed running after launch