### PR TITLE
Fix OptiScaler status feedback and panel reload after move to Extras

### DIFF
--- a/RenoDXCommander/DetailPanelBuilder.Components.cs
+++ b/RenoDXCommander/DetailPanelBuilder.Components.cs
@@ -532,10 +532,6 @@ public partial class DetailPanelBuilder
         _window.DetailDcMessage.Visibility = card.DcRowVisibility == Visibility.Visible ? card.DcMessageVisibility : Visibility.Collapsed;
         _window.DetailDcMessage.Text = card.DcActionMessage;
         _window.DetailDcMessage.Foreground = UIFactory.GetBrush(GetMessageColor(card.DcActionMessage));
-        _window.DetailOsProgress.Visibility = card.OsRowVisibility == Visibility.Visible ? card.OsProgressVisibility : Visibility.Collapsed;
-        // OptiScaler message lives in the Extras section — suppress it from Components
-        _window.DetailOsProgress.Visibility = Visibility.Collapsed;
-        _window.DetailOsMessage.Visibility  = Visibility.Collapsed;
         _window.DetailDofFixProgress.Visibility = card.DofFixRowVisibility == Visibility.Visible ? card.DofFixProgressVisibility : Visibility.Collapsed;
         _window.DetailDofFixProgress.Value = card.DofFixProgress;
         _window.DetailDofFixMessage.Visibility = card.DofFixRowVisibility == Visibility.Visible ? card.DofFixMessageVisibility : Visibility.Collapsed;
@@ -567,6 +563,7 @@ public partial class DetailPanelBuilder
         {
             if (_currentDetailCard == null) return;
             UpdateDetailComponentRows(_currentDetailCard);
+            OnExtrasCardPropertyChanged(_currentDetailCard, e.PropertyName);
 
             // Refresh 32-bit / 64-bit badge when bitness changes
             if (e.PropertyName is "Is32Bit" or "Is32BitBadgeVisibility")

--- a/RenoDXCommander/DetailPanelBuilder.Extras.cs
+++ b/RenoDXCommander/DetailPanelBuilder.Extras.cs
@@ -249,13 +249,13 @@ public partial class DetailPanelBuilder
                     _window.ViewModel.SetUalInstalledAs(gameName, chosen, store);
                     if (hookedOriginal != null)
                     {
-                        _ = new ContentDialog
+                        _ = DialogService.ShowSafeAsync(new ContentDialog
                         {
                             Title = "Original DLL chained",
                             Content = $"The existing '{chosen}' was renamed to '{hookedOriginal}' so ASI Loader can chain-load it automatically.",
                             CloseButtonText = "OK",
                             XamlRoot = _window.Content.XamlRoot,
-                        }.ShowAsync();
+                        });
                     }
                     _window.DispatcherQueue.TryEnqueue(() => _window.BuildOverridesPanel(card));
                 }
@@ -294,7 +294,7 @@ public partial class DetailPanelBuilder
                 CloseButtonText = "Close",
                 XamlRoot = _window.Content.XamlRoot,
             };
-            await dlg.ShowAsync();
+            await DialogService.ShowSafeAsync(dlg);
         };
         Grid.SetColumn(cogBtn, 4);
         row.Children.Add(cogBtn);
@@ -600,7 +600,7 @@ public partial class DetailPanelBuilder
             XamlRoot = _window.Content.XamlRoot,
         };
 
-        await dialog.ShowAsync();
+        await DialogService.ShowSafeAsync(dialog);
         return chosen;
     }
 
@@ -828,7 +828,7 @@ public partial class DetailPanelBuilder
                 XamlRoot = _window.Content.XamlRoot,
                 RequestedTheme = ElementTheme.Dark,
             };
-            var result = await dlg.ShowAsync();
+            var result = await DialogService.ShowSafeAsync(dlg);
             if (result == ContentDialogResult.Primary)
                 _ = Windows.System.Launcher.LaunchUriAsync(new Uri("https://github.com/dashdogy/RTX40MFG-Unlock"));
         };

--- a/RenoDXCommander/DetailPanelBuilder.Extras.cs
+++ b/RenoDXCommander/DetailPanelBuilder.Extras.cs
@@ -78,6 +78,46 @@ public partial class DetailPanelBuilder
 
         // ── OptiScaler row ────────────────────────────────────────────────────
         BuildOsRow(card, exBody);
+
+        UpdateOsFeedback(card);
+    }
+
+    
+    public void OnExtrasCardPropertyChanged(GameCardViewModel card, string? propertyName)
+    {
+        UpdateOsFeedback(card);
+
+        if (propertyName is "IsOsInstalled" or "OsActionLabel" or "OsStatusText"
+            or "OsStatusColor" or "OsDeleteVisibility" or "OsRowVisibility"
+            or "OsInstallEnabled" or "OsBtnBackground" or "OsInstalledFile" or "Is32Bit")
+        {
+            RequestExtrasRebuild(card);
+        }
+    }
+
+    
+    public void UpdateOsFeedback(GameCardViewModel card)
+    {
+        _window.DetailOsProgress.Visibility = card.OsRowVisibility == Visibility.Visible ? card.OsProgressVisibility : Visibility.Collapsed;
+        _window.DetailOsProgress.Value = card.OsProgress;
+        _window.DetailOsMessage.Visibility = card.OsRowVisibility == Visibility.Visible ? card.OsMessageVisibility : Visibility.Collapsed;
+        _window.DetailOsMessage.Text = card.OsActionMessage;
+        _window.DetailOsMessage.Foreground = UIFactory.GetBrush(GetMessageColor(card.OsActionMessage));
+    }
+
+    
+    private bool _extrasRebuildPending;
+
+    public void RequestExtrasRebuild(GameCardViewModel card)
+    {
+        if (_extrasRebuildPending) return;
+        _extrasRebuildPending = true;
+        _window.DispatcherQueue.TryEnqueue(() =>
+        {
+            _extrasRebuildPending = false;
+            if (_currentDetailCard != card) return;
+            BuildExtrasSection(card);
+        });
     }
 
     private void BuildUalRow(GameCardViewModel card, StackPanel body)
@@ -209,13 +249,13 @@ public partial class DetailPanelBuilder
                     _window.ViewModel.SetUalInstalledAs(gameName, chosen, store);
                     if (hookedOriginal != null)
                     {
-                        _ = DialogService.ShowSafeAsync(new ContentDialog
+                        _ = new ContentDialog
                         {
                             Title = "Original DLL chained",
                             Content = $"The existing '{chosen}' was renamed to '{hookedOriginal}' so ASI Loader can chain-load it automatically.",
                             CloseButtonText = "OK",
                             XamlRoot = _window.Content.XamlRoot,
-                        });
+                        }.ShowAsync();
                     }
                     _window.DispatcherQueue.TryEnqueue(() => _window.BuildOverridesPanel(card));
                 }
@@ -254,7 +294,7 @@ public partial class DetailPanelBuilder
                 CloseButtonText = "Close",
                 XamlRoot = _window.Content.XamlRoot,
             };
-            await DialogService.ShowSafeAsync(dlg);
+            await dlg.ShowAsync();
         };
         Grid.SetColumn(cogBtn, 4);
         row.Children.Add(cogBtn);
@@ -377,17 +417,7 @@ public partial class DetailPanelBuilder
             IsHitTestVisible = !osGreyed,
         };
         installBtn.Content = WithInfoArrow(card.OsActionLabel, HasRealInfoContent(card, AddonType.OptiScaler), card.OsStatus == GameStatus.UpdateAvailable, installBtn);
-        installBtn.Click += async (s, e) =>
-        {
-            _window.InstallOsButton_Click(s, e);
-            // Poll until OsIsInstalling is done, then rebuild the panel
-            await Task.Run(async () =>
-            {
-                while (card.OsIsInstalling)
-                    await Task.Delay(100).ConfigureAwait(false);
-            });
-            _window.DispatcherQueue?.TryEnqueue(() => _window.BuildOverridesPanel(card));
-        };
+        installBtn.Click += (s, e) => _window.InstallOsButton_Click(s, e);
         Grid.SetColumn(installBtn, 3);
         row.Children.Add(installBtn);
 
@@ -430,13 +460,7 @@ public partial class DetailPanelBuilder
             IsHitTestVisible = osShow && !osGreyed,
         };
         ToolTipService.SetToolTip(deleteBtn, "Remove OptiScaler");
-        deleteBtn.Click += async (s, e) =>
-        {
-            _window.UninstallOsButton_Click(s, e);
-            // Uninstall is synchronous — rebuild immediately on next tick
-            await Task.Delay(50);
-            _window.DispatcherQueue?.TryEnqueue(() => _window.BuildOverridesPanel(card));
-        };
+        deleteBtn.Click += (s, e) => _window.UninstallOsButton_Click(s, e);
         Grid.SetColumn(deleteBtn, 5);
         row.Children.Add(deleteBtn);
 
@@ -576,7 +600,7 @@ public partial class DetailPanelBuilder
             XamlRoot = _window.Content.XamlRoot,
         };
 
-        await DialogService.ShowSafeAsync(dialog);
+        await dialog.ShowAsync();
         return chosen;
     }
 
@@ -804,7 +828,7 @@ public partial class DetailPanelBuilder
                 XamlRoot = _window.Content.XamlRoot,
                 RequestedTheme = ElementTheme.Dark,
             };
-            var result = await DialogService.ShowSafeAsync(dlg);
+            var result = await dlg.ShowAsync();
             if (result == ContentDialogResult.Primary)
                 _ = Windows.System.Launcher.LaunchUriAsync(new Uri("https://github.com/dashdogy/RTX40MFG-Unlock"));
         };

--- a/RenoDXCommander/MainWindow.xaml
+++ b/RenoDXCommander/MainWindow.xaml
@@ -1052,11 +1052,6 @@
                                                  Foreground="{StaticResource AccentBlueBrush}" Background="{StaticResource SurfaceToolbarBrush}"/>
                                     <TextBlock x:Name="DetailDcMessage" x:FieldModifier="internal" FontSize="10" Foreground="{StaticResource AccentBlueBrush}"
                                                Visibility="Collapsed" TextWrapping="Wrap"/>
-                                    <ProgressBar x:Name="DetailOsProgress" x:FieldModifier="internal" Visibility="Collapsed"
-                                                 Maximum="100" Height="3" CornerRadius="2"
-                                                 Foreground="{StaticResource AccentBlueBrush}" Background="{StaticResource SurfaceToolbarBrush}"/>
-                                    <TextBlock x:Name="DetailOsMessage" x:FieldModifier="internal" FontSize="10" Foreground="{StaticResource AccentBlueBrush}"
-                                               Visibility="Collapsed" TextWrapping="Wrap"/>
                                     <ProgressBar x:Name="DetailDofFixProgress" x:FieldModifier="internal" Visibility="Collapsed"
                                                  Maximum="100" Height="3" CornerRadius="2"
                                                  Foreground="{StaticResource AccentBlueBrush}" Background="{StaticResource SurfaceToolbarBrush}"/>
@@ -1124,7 +1119,14 @@
                                 Background="{StaticResource SurfaceComponentTableBrush}" CornerRadius="12"
                                 BorderBrush="{StaticResource BorderDefaultBrush}" BorderThickness="1"
                                 Padding="14,12" Visibility="Collapsed">
-                            <StackPanel x:Name="ExtrasPanel" x:FieldModifier="internal" Spacing="6"/>
+                            <StackPanel Spacing="6">
+                                <StackPanel x:Name="ExtrasPanel" x:FieldModifier="internal" Spacing="6"/>
+                                <ProgressBar x:Name="DetailOsProgress" x:FieldModifier="internal" Visibility="Collapsed"
+                                             Maximum="100" Height="3" CornerRadius="2"
+                                             Foreground="{StaticResource AccentBlueBrush}" Background="{StaticResource SurfaceToolbarBrush}"/>
+                                <TextBlock x:Name="DetailOsMessage" x:FieldModifier="internal" FontSize="10" Foreground="{StaticResource AccentBlueBrush}"
+                                           Visibility="Collapsed" TextWrapping="Wrap"/>
+                            </StackPanel>
                         </Border>
                     </StackPanel>
                 </ScrollViewer>


### PR DESCRIPTION
OptiScaler's progress bar and status message were still in the Components card, and the
current fix hides them and calls BuildOverridesPanel to refresh the row, so there's no
install feedback and the panel scroll resets every time.

- MainWindow.xaml: moved DetailOsProgress/DetailOsMessage into ExtrasContainer.
- DetailPanelBuilder.Components.cs: dropped the suppression lines, forwards property
  changes to OnExtrasCardPropertyChanged.
- DetailPanelBuilder.Extras.cs: added UpdateOsFeedback, OnExtrasCardPropertyChanged and
  RequestExtrasRebuild so only the Extras section rebuilds. Install/delete buttons back to
  plain InstallOsButton_Click / UninstallOsButton_Click.

Messages now show under the OptiScaler row and update live, scroll stays put.