### PR TITLE
Add DLSS5 ReShade AIO installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ RHI replaces the ReShade installer entirely.
 
 ### DLSS 5 and Neural Rendering
 
+- **DLSS5 ReShade AIO** — standalone Present-time Neural Rendering, DLSS/DLAA, and NVIDIA Frame Generation for games without native DLSS support. RHI selects the correct 32/64-bit release, installs its shaders and NVIDIA runtimes, and builds the required `host64` wrapper environment for 32-bit games automatically.
 - **DLSS5 Feeder** — full pipeline install in one click: deploys feeder addon, DLSS5 consumer, `nvngx_dlss.dll`, `nvngx_dlssnr.dll`, pre-configured `ReShadePreset.ini`, and required shader packs. Auto-selects the right method for your game (32-bit, DX11, DX12).
 - **ShortFuse DLSS Tool** — alternative neural rendering implementation for DX12 games.
 - **DX11 Bridge variant** — DLSS5 Tool + bridge for games that need DX11 compatibility.

--- a/RenoDXCommander.Tests/Dlss5AioServiceTests.cs
+++ b/RenoDXCommander.Tests/Dlss5AioServiceTests.cs
@@ -1,0 +1,55 @@
+using RenoDXCommander.Services;
+using Xunit;
+
+namespace RenoDXCommander.Tests;
+
+public class Dlss5AioServiceTests
+{
+    private static readonly Dlss5AioService.ReleaseAsset[] Assets =
+    {
+        new("DLSS5-ReShade-AIO-v2.1.3-32-bit.zip", "https://example.invalid/x86"),
+        new("DLSS5-ReShade-AIO-v2.1.3-SHA256.txt", "https://example.invalid/checksum"),
+        new("DLSS5-ReShade-AIO-v2.1.3-64-bit.zip", "https://example.invalid/x64"),
+    };
+
+    [Fact]
+    public void SelectArchitectureAsset_Selects32BitZip()
+    {
+        var result = Dlss5AioService.SelectArchitectureAsset(Assets, is32Bit: true);
+        Assert.NotNull(result);
+        Assert.EndsWith("-32-bit.zip", result.Name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SelectArchitectureAsset_Selects64BitZip()
+    {
+        var result = Dlss5AioService.SelectArchitectureAsset(Assets, is32Bit: false);
+        Assert.NotNull(result);
+        Assert.EndsWith("-64-bit.zip", result.Name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SelectArchitectureAsset_RejectsUnrelatedZip()
+    {
+        var result = Dlss5AioService.SelectArchitectureAsset(
+            new[] { new Dlss5AioService.ReleaseAsset("another-mod-64-bit.zip", "https://example.invalid") },
+            is32Bit: false);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryResolveUnderRoot_AcceptsPackageSubpath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "rhi-aio-test");
+        Assert.True(Dlss5AioService.TryResolveUnderRoot(
+            root, "host64/reshade-shaders/Shaders/DLSS5_AIO_Feed.fx", out var result));
+        Assert.StartsWith(Path.GetFullPath(root), result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryResolveUnderRoot_RejectsZipTraversal()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "rhi-aio-test");
+        Assert.False(Dlss5AioService.TryResolveUnderRoot(root, "../outside.dll", out _));
+    }
+}

--- a/RenoDXCommander/App.xaml.cs
+++ b/RenoDXCommander/App.xaml.cs
@@ -114,6 +114,7 @@ public partial class App : Application
         services.AddSingleton<AutoUpdateService>();
         services.AddSingleton<DlssEnablerService>();
         services.AddSingleton<Renodx5AddonService>();
+        services.AddSingleton<Dlss5AioService>();
         services.AddSingleton<CustomReShadeHashService>();
         services.AddSingleton<SeenWikiModsService>();
         services.AddSingleton<SeenUltraPlusModsService>();

--- a/RenoDXCommander/DetailPanelBuilder.NeuralRendering.cs
+++ b/RenoDXCommander/DetailPanelBuilder.NeuralRendering.cs
@@ -1,6 +1,7 @@
 // DetailPanelBuilder.NeuralRendering.cs — Self-contained Neural Rendering section.
 // Shown between Game Overrides and NVIDIA Profile Overrides.
-// Handles DLSS5 Tool, DLSS5 Tool + DX11 Bridge, DLSS Tool (ShortFuse), and DLSS5 Feeder.
+// Handles DLSS5 Tool, DLSS5 Tool + DX11 Bridge, DLSS Tool (ShortFuse), DLSS5 Feeder,
+// and DLSS5 ReShade AIO.
 // All files are deployed automatically — no addon picker required.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +27,7 @@ public partial class DetailPanelBuilder
     private const string NrMethodDlss5ToolBridge  = "DLSS5ToolBridge";
     private const string NrMethodShortFuse         = "ShortFuse";
     private const string NrMethodFeeder            = "Feeder";
+    private const string NrMethodDlss5Aio          = "DLSS5AIO";
 
     public void BuildNeuralRenderingSection(GameCardViewModel card)
     {
@@ -58,11 +60,12 @@ public partial class DetailPanelBuilder
                 nrDllVersion = DlssStreamlineService.FormatVersion(dlssSvc.GetFileVersion(Path.Combine(installPath, "nvngx_dlssnr.dll")));
             bool bridgePresent = File.Exists(Path.Combine(installPath, BridgeDeployFile));
             bool feederPresent = File.Exists(Path.Combine(installPath, card.Is32Bit ? FeederDeployFile32 : FeederDeployFile64));
+            bool aioPresent = Dlss5AioService.IsInstalled(installPath, card.Is32Bit);
 
             _window.DispatcherQueue?.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
             {
                 BuildNeuralRenderingSectionWithData(card, dlss5Installed, sfInstalled,
-                    nrDllPresent, nrDllOwnedByRhi, nrDllVersion, bridgePresent, feederPresent);
+                    nrDllPresent, nrDllOwnedByRhi, nrDllVersion, bridgePresent, feederPresent, aioPresent);
             });
             }
             finally { _panelScanSemaphore.Release(); }
@@ -73,7 +76,7 @@ public partial class DetailPanelBuilder
         GameCardViewModel card,
         bool dlss5Installed, bool sfInstalled,
         bool nrDllPresent, bool nrDllOwnedByRhi, string? nrDllVersion,
-        bool bridgePresent, bool feederPresent)
+        bool bridgePresent, bool feederPresent, bool aioPresent)
     {
         // Guard: if the user navigated away before the background scan finished, bail out
         if (_window.ViewModel.SelectedGame != card) return;
@@ -86,6 +89,7 @@ public partial class DetailPanelBuilder
         var store       = card.Source ?? "";
 
         var rdx5Svc     = App.Services.GetRequiredService<Renodx5AddonService>();
+        var aioSvc      = App.Services.GetRequiredService<Dlss5AioService>();
         var addonSvc    = _window.ViewModel.AddonPackServiceInstance;
         var dlssSvc     = _dlssStreamlineService;
         bool hasDlss  = card.HasAnyDlssStreamline;
@@ -100,7 +104,9 @@ public partial class DetailPanelBuilder
         if (storedMethod == null)
         {
             // Infer from what's on disk
-            if (sfInstalled)
+            if (aioPresent)
+                storedMethod = NrMethodDlss5Aio;
+            else if (sfInstalled)
                 storedMethod = NrMethodShortFuse;
             else if (dlss5Installed && bridgePresent)
                 storedMethod = NrMethodDlss5ToolBridge;
@@ -124,6 +130,7 @@ public partial class DetailPanelBuilder
             new { Name = "DLSS5 Tool + DX11 Bridge",  Key = NrMethodDlss5ToolBridge, Enabled = hasDlss && (isDx11 || isVulkan) && !is32Bit },
             new { Name = "DLSS Tool (ShortFuse)",      Key = NrMethodShortFuse,       Enabled = !is32Bit },
             new { Name = "DLSS5 Feeder",               Key = NrMethodFeeder,          Enabled = true },
+            new { Name = "DLSS5 ReShade AIO",          Key = NrMethodDlss5Aio,        Enabled = true },
         };
 
         // ── Header ────────────────────────────────────────────────────────────
@@ -202,7 +209,8 @@ public partial class DetailPanelBuilder
             "DLSS5 Tool: for DX12 native-DLSS games.\n" +
             "DLSS5 Tool + DX11 Bridge: for DX11/Vulkan native-DLSS games.\n" +
             "DLSS Tool (ShortFuse): alternative full-stack install for native-DLSS games.\n" +
-            "DLSS5 Feeder: for games with no native DLSS (DX11, DX12, Vulkan, 32-bit).");
+            "DLSS5 Feeder: for games with no native DLSS (DX11, DX12, Vulkan, 32-bit).\n" +
+            "DLSS5 ReShade AIO: standalone NR + DLSS/DLAA + Frame Generation at Present, including a 32-bit host wrapper.");
         methodStack.Children.Add(methodCombo);
         Grid.SetColumn(methodStack, 0);
         row1.Children.Add(methodStack);
@@ -248,6 +256,7 @@ public partial class DetailPanelBuilder
                 bool nri    = File.Exists(Path.Combine(installPath, "nvngx_dlssnr.dll"));
                 bool bri    = File.Exists(Path.Combine(installPath, BridgeDeployFile));
                 bool fei    = File.Exists(Path.Combine(installPath, card.Is32Bit ? FeederDeployFile32 : FeederDeployFile64));
+                bool aii    = Dlss5AioService.IsInstalled(installPath, card.Is32Bit);
                 bool rsi    = card.IsRsInstalled;
                 bool dlssi  = File.Exists(Path.Combine(installPath, "nvngx_dlss.dll"));
                 bool dlssdi = File.Exists(Path.Combine(installPath, "nvngx_dlssd.dll"));
@@ -260,7 +269,7 @@ public partial class DetailPanelBuilder
                 _window.DispatcherQueue?.TryEnqueue(() =>
                 {
                     if (_window.ViewModel.SelectedGame != card) return;
-                    RefreshStatusWithData(d5i, sfi, nri, bri, fei, rsi, dlssi, dlssdi, dlssgi, nrv, dlssv, dlssdv, dlssgv);
+                    RefreshStatusWithData(d5i, sfi, nri, bri, fei, aii, rsi, dlssi, dlssdi, dlssgi, nrv, dlssv, dlssdv, dlssgv);
                 });
                 }
                 finally { _panelScanSemaphore.Release(); }
@@ -268,7 +277,7 @@ public partial class DetailPanelBuilder
         }
 
         void RefreshStatusWithData(
-            bool d5i, bool sfi, bool nri, bool bri, bool fei, bool rsi,
+            bool d5i, bool sfi, bool nri, bool bri, bool fei, bool aii, bool rsi,
             bool dlssi, bool dlssdi, bool dlssgi,
             string? nrv, string? dlssv, string? dlssdv, string? dlssgv)
         {
@@ -373,6 +382,24 @@ public partial class DetailPanelBuilder
                     Tag(feedFxPresent    ? "✓ Feed.fx"    : "✗ Feed.fx",    feedFxPresent);
                     Tag(lumeniteFxPresent ? "✓ LumeniteFX" : "✗ LumeniteFX", lumeniteFxPresent);
                     break;
+                case NrMethodDlss5Aio:
+                {
+                    Tag(aii ? "✓ DLSS5 ReShade AIO" : "✗ DLSS5 ReShade AIO", aii);
+                    var runtimeRoot = card.Is32Bit ? Path.Combine(installPath, "host64") : installPath;
+                    var sr = Path.Combine(runtimeRoot, "nvngx_dlss.dll");
+                    var fg = Path.Combine(runtimeRoot, "nvngx_dlssg.dll");
+                    var nr = Path.Combine(runtimeRoot, "nvngx_dlssnr.dll");
+                    bool srOk = File.Exists(sr), fgOk = File.Exists(fg), nrOk = File.Exists(nr);
+                    Tag(srOk ? $"✓ DLSS SR {DlssStreamlineService.FormatVersion(dlssSvc.GetFileVersion(sr))}" : "✗ DLSS SR", srOk);
+                    Tag(fgOk ? $"✓ DLSS FG {DlssStreamlineService.FormatVersion(dlssSvc.GetFileVersion(fg))}" : "✗ DLSS FG", fgOk);
+                    Tag(nrOk ? $"✓ NR DLL {DlssStreamlineService.FormatVersion(dlssSvc.GetFileVersion(nr))}" : "✗ NR DLL", nrOk);
+                    if (card.Is32Bit)
+                    {
+                        var hostRs = Path.Combine(runtimeRoot, "dxgi.dll");
+                        Tag(File.Exists(hostRs) ? "✓ x64 Host" : "✗ x64 Host", File.Exists(hostRs));
+                    }
+                    break;
+                }
                 default:
                     Tag("Not installed", false);
                     break;
@@ -434,6 +461,13 @@ public partial class DetailPanelBuilder
                         : "For games with no native DLSS (DX11, DX12, Vulkan, OpenGL). Feeds a synthetic DLSS contract from ReShade depth and motion vectors. Deploys the Feeder addon, DLSS5 Tool (neural consumer), NR DLL, DLSS SR DLL, and required shaders.";
                     descLink.Content = "Feeder setup guide →";
                     descLink.NavigateUri = new Uri("https://github.com/jlrouzies-fr/DLSS5-Feeder");
+                    break;
+                case NrMethodDlss5Aio:
+                    descText.Text = is32Bit
+                        ? "Standalone Present-time NR, DLSS/DLAA, and NVIDIA Frame Generation for 32-bit games. RHI installs the x86 addon and automatically builds the required 64-bit host environment. Native game DLSS support is not required."
+                        : "Standalone Present-time NR, DLSS/DLAA, and NVIDIA Frame Generation for 64-bit DX9–12 and Vulkan games. Native game DLSS support is not required.";
+                    descLink.Content = "DLSS5 ReShade AIO setup and troubleshooting →";
+                    descLink.NavigateUri = new Uri(Dlss5AioService.RepositoryUrl);
                     break;
             }
         }
@@ -548,15 +582,17 @@ public partial class DetailPanelBuilder
                 NrMethodDlss5ToolBridge => rdx5Svc.IsInstalledIn(installPath) || File.Exists(Path.Combine(installPath, BridgeDeployFile)),
                 NrMethodShortFuse       => rdx5Svc.IsSfInstalledIn(installPath),
                 NrMethodFeeder          => File.Exists(Path.Combine(installPath, card.Is32Bit ? FeederDeployFile32 : FeederDeployFile64)),
+                NrMethodDlss5Aio        => Dlss5AioService.IsInstalled(installPath, card.Is32Bit),
                 _                       => false,
             };
 
             bool isFeeder = selKey == NrMethodFeeder;
+            bool isAio = selKey == NrMethodDlss5Aio;
 
             // Install button appearance
-            if (isFeeder)
+            if (isFeeder || isAio)
             {
-                installBtn.Content = "Install Feeder Addon";
+                installBtn.Content = isAio ? "Install DLSS5 AIO" : "Install Feeder Addon";
                 installBtn.Background  = UIFactory.Brush(ResourceKeys.AccentBlueBgBrush);
                 installBtn.Foreground  = UIFactory.Brush(ResourceKeys.AccentBlueBrush);
                 installBtn.BorderBrush = UIFactory.Brush(ResourceKeys.AccentBlueBorderBrush);
@@ -621,6 +657,7 @@ public partial class DetailPanelBuilder
                 NrMethodDlss5ToolBridge => rdx5Svc.IsInstalledIn(installPath) || File.Exists(Path.Combine(installPath, BridgeDeployFile)),
                 NrMethodShortFuse       => rdx5Svc.IsSfInstalledIn(installPath),
                 NrMethodFeeder          => File.Exists(Path.Combine(installPath, card.Is32Bit ? FeederDeployFile32 : FeederDeployFile64)),
+                NrMethodDlss5Aio        => Dlss5AioService.IsInstalled(installPath, card.Is32Bit),
                 _                       => false,
             };
 
@@ -678,6 +715,10 @@ public partial class DetailPanelBuilder
                                 RemoveFeederShaders(installPath, gameName, store, card);
                                 break;
                             }
+
+                            case NrMethodDlss5Aio:
+                                aioSvc.Uninstall(installPath);
+                                break;
                         }
                         CrashReporter.Log($"[NeuralRendering.MethodSwitch] Removed '{previousKey}', switching to '{selKey}' for '{gameName}'");
                     });
@@ -742,10 +783,14 @@ public partial class DetailPanelBuilder
                     case NrMethodFeeder:
                         await InstallFeederAddonAsync(card, installBtn, addonSvc);
                         break;
+
+                    case NrMethodDlss5Aio:
+                        await InstallDlss5AioAsync(card, installBtn, aioSvc);
+                        break;
                 }
 
                 // If Cost Scaler preference is On, deploy it now (NR DLL is freshly placed)
-                if (_window.ViewModel.GetNrCostScalerEnabled(gameName, store))
+                if (selKey != NrMethodDlss5Aio && _window.ViewModel.GetNrCostScalerEnabled(gameName, store))
                 {
                     var csSvc = App.Services.GetRequiredService<DlssNrCostScalerService>();
                     if (csSvc.IsStagingReady)
@@ -759,7 +804,9 @@ public partial class DetailPanelBuilder
                 // that conflict with the NR section. Remove them from the global set so they don't
                 // get re-deployed on every refresh.
                 var globalAddons = _window.ViewModel.Settings.EnabledGlobalAddons;
-                var conflicting  = new[] { "DLSS5 Tool", "DLSS Tool (ShortFuse)" };
+                var conflicting = selKey == NrMethodDlss5Aio
+                    ? new[] { "DLSS5 Tool", "DLSS Tool (ShortFuse)", BridgePackageName, FeederPackageName }
+                    : new[] { "DLSS5 Tool", "DLSS Tool (ShortFuse)" };
                 bool removedAny  = false;
                 foreach (var c in conflicting)
                     if (globalAddons.RemoveAll(a => a.Equals(c, StringComparison.OrdinalIgnoreCase)) > 0)
@@ -767,7 +814,7 @@ public partial class DetailPanelBuilder
                 if (removedAny)
                 {
                     _window.ViewModel.SaveSettingsPublic();
-                    CrashReporter.Log($"[NeuralRendering.Install] Removed conflicting global addons (DLSS5 Tool / ShortFuse) for '{gameName}'");
+                    CrashReporter.Log($"[NeuralRendering.Install] Removed conflicting global neural addons for '{gameName}'");
                 }
 
                 // Re-deploy addons for this game so stale NR addon files are removed immediately
@@ -861,6 +908,10 @@ public partial class DetailPanelBuilder
                             RemoveFeederShaders(installPath, gameName, store, card);
                             break;
                         }
+
+                        case NrMethodDlss5Aio:
+                            aioSvc.Uninstall(installPath);
+                            break;
                     }
 
                     _window.ViewModel.SetNrMethodOverride(gameName, null, store);
@@ -905,9 +956,10 @@ public partial class DetailPanelBuilder
         // ── NR Cost Scaler preference toggle ─────────────────────────────────
         var costScalerSvc = App.Services.GetRequiredService<DlssNrCostScalerService>();
         bool costScalerPref = _window.ViewModel.GetNrCostScalerEnabled(gameName, store);
-        bool nrMethodInstalled = dlss5Installed || sfInstalled || feederPresent || bridgePresent;
+        bool nrMethodInstalled = dlss5Installed || sfInstalled || feederPresent || bridgePresent || aioPresent;
+        bool costScalerSupported = effectiveMethod != NrMethodDlss5Aio;
         // Toggle is disabled when NR is already installed (must be set before install) or staging not ready
-        bool costScalerToggleEnabled = costScalerSvc.IsStagingReady && !nrMethodInstalled;
+        bool costScalerToggleEnabled = costScalerSupported && costScalerSvc.IsStagingReady && !nrMethodInstalled;
 
         var costScalerRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 10,
             Margin = new Thickness(0, 4, 0, 0) };
@@ -930,7 +982,9 @@ public partial class DetailPanelBuilder
             IsEnabled = costScalerToggleEnabled,
             Opacity = costScalerToggleEnabled ? 1.0 : 0.45,
         };
-        if (!costScalerSvc.IsStagingReady)
+        if (!costScalerSupported)
+            ToolTipService.SetToolTip(costScalerToggle, "DLSS5 ReShade AIO has its own Pipeline Source Resolution Override; NR Cost Scaler is not used.");
+        else if (!costScalerSvc.IsStagingReady)
             ToolTipService.SetToolTip(costScalerToggle, "Cost Scaler not yet staged — will be available after first launch");
         else if (nrMethodInstalled)
             ToolTipService.SetToolTip(costScalerToggle, "Remove the installed NR method first, then toggle Cost Scaler On before reinstalling");
@@ -968,10 +1022,37 @@ public partial class DetailPanelBuilder
         linksRow.Children.Add(MakeLink("DX11 Bridge →", "https://github.com/NIGos/dlss5-bridge"));
         linksRow.Children.Add(MakeLink("ShortFuse →",   "https://discord.com/channels/1408098019194310818/1543975158937821315"));
         linksRow.Children.Add(MakeLink("Feeder →",      "https://github.com/jlrouzies-fr/DLSS5-Feeder"));
+        linksRow.Children.Add(MakeLink("DLSS5 AIO →",   Dlss5AioService.RepositoryUrl));
         nrBody.Children.Add(linksRow);
     }
 
     // ── Install helpers ───────────────────────────────────────────────────────
+
+    private async Task InstallDlss5AioAsync(
+        GameCardViewModel card,
+        Button statusBtn,
+        Dlss5AioService aioSvc)
+    {
+        var progress = new Progress<string>(message =>
+            _window.DispatcherQueue?.TryEnqueue(() => statusBtn.Content = message));
+        await aioSvc.InstallAsync(card.InstallPath!, card.Is32Bit, progress).ConfigureAwait(false);
+
+        // Native x64 installs expose the runtimes to RHI's normal detection.
+        // The x86 wrapper keeps them in host64 by design, so it is represented by
+        // the AIO-specific status tags instead.
+        if (!card.Is32Bit)
+        {
+            var detection = _dlssStreamlineService.Detect(card.InstallPath!);
+            _dlssStreamlineService.RecordDlssFound(card.GameName);
+            _dlssStreamlineService.RecordTrustedPath(card.GameName, detection);
+            _window.DispatcherQueue?.TryEnqueue(() =>
+            {
+                card.DlssDetection = detection;
+                card.ApplyDlssDetection(detection);
+                card.RefreshDlssVersions(_dlssStreamlineService);
+            });
+        }
+    }
 
     private async Task InstallDlss5ToolAsync(
         GameCardViewModel card,

--- a/RenoDXCommander/Services/Dlss5AioService.cs
+++ b/RenoDXCommander/Services/Dlss5AioService.cs
@@ -1,0 +1,364 @@
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace RenoDXCommander.Services;
+
+/// <summary>
+/// Downloads and deploys DLSS5 ReShade AIO. The upstream release has different
+/// layouts for native 64-bit games and the 32-bit host-wrapper path, so it cannot
+/// use the generic addon pack extractor (which intentionally extracts addons only).
+/// </summary>
+public sealed class Dlss5AioService
+{
+    internal const string RepositoryUrl = "https://github.com/kibblerz/DLSS5-Reshade-AIO";
+    internal const string LatestReleaseApiUrl = "https://api.github.com/repos/kibblerz/DLSS5-Reshade-AIO/releases/latest";
+
+    private const string MarkerFileName = ".rhi-dlss5-aio.json";
+    private const string BackupSuffix = ".rhi-dlss5-aio.original";
+    private static readonly string CacheRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "RHI", "DLSS5-AIO");
+
+    private readonly HttpClient _http;
+    private readonly IDlssStreamlineService _dlssService;
+    private readonly GitHubETagCache _etagCache;
+
+    public Dlss5AioService(
+        HttpClient http,
+        IDlssStreamlineService dlssService,
+        GitHubETagCache etagCache)
+    {
+        _http = http;
+        _dlssService = dlssService;
+        _etagCache = etagCache;
+    }
+
+    public static bool IsInstalled(string installPath, bool is32Bit)
+    {
+        if (string.IsNullOrWhiteSpace(installPath)) return false;
+        var addon = Path.Combine(installPath, is32Bit
+            ? "standalone-dlssnr.addon32"
+            : "standalone-dlssnr.addon64");
+        var bridge = Path.Combine(installPath, is32Bit ? "host64" : "", "nvngx.dll");
+        return File.Exists(addon) && File.Exists(bridge);
+    }
+
+    public async Task<string> InstallAsync(
+        string installPath,
+        bool is32Bit,
+        IProgress<string>? progress = null)
+    {
+        if (string.IsNullOrWhiteSpace(installPath) || !Directory.Exists(installPath))
+            throw new DirectoryNotFoundException($"Game folder not found: {installPath}");
+
+        progress?.Report("Finding latest DLSS5 AIO release...");
+        var release = await GetLatestReleaseAsync().ConfigureAwait(false);
+        var asset = SelectArchitectureAsset(release.Assets, is32Bit)
+            ?? throw new InvalidOperationException(
+                $"The latest DLSS5 AIO release does not contain a {(is32Bit ? "32" : "64")}-bit ZIP.");
+
+        var stagedRoot = await EnsurePackageCachedAsync(release.TagName, asset, is32Bit, progress)
+            .ConfigureAwait(false);
+
+        ValidatePackage(stagedRoot, is32Bit);
+
+        // Resolve every external dependency before touching the game folder.
+        if (is32Bit && (!File.Exists(AuxInstallService.RsStagedPath64) ||
+            new FileInfo(AuxInstallService.RsStagedPath64).Length <= AuxInstallService.MinReShadeSize))
+        {
+            throw new InvalidOperationException(
+                "64-bit addon-enabled ReShade is not staged. Update/install ReShade in RHI, then retry.");
+        }
+
+        progress?.Report("Downloading NVIDIA DLSS runtimes...");
+        await _dlssService.FetchManifestAsync().ConfigureAwait(false);
+        var cachedSr = await _dlssService.EnsureNewestDlssCachedAsync().ConfigureAwait(false);
+        var cachedFg = await _dlssService.EnsureNewestDlssgCachedAsync().ConfigureAwait(false);
+        var cachedNr = await _dlssService.EnsureNewestDlssnrCachedAsync().ConfigureAwait(false);
+        ValidateRuntime(cachedSr, "nvngx_dlss.dll");
+        ValidateRuntime(cachedFg, "nvngx_dlssg.dll");
+        ValidateRuntime(cachedNr, "nvngx_dlssnr.dll");
+
+        // A reinstall first restores files removed from a newer/older package manifest,
+        // then creates a fresh deployment record.
+        if (File.Exists(Path.Combine(installPath, MarkerFileName)))
+            Uninstall(installPath);
+
+        var deployed = new List<string>();
+        try
+        {
+            progress?.Report("Deploying DLSS5 AIO files...");
+            foreach (var source in Directory.EnumerateFiles(stagedRoot, "*", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(stagedRoot, source);
+                if (relative.Equals("host64\\ADD_REQUIRED_64BIT_FILES_HERE.txt", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                deployed.Add(relative);
+                DeployWithBackup(source, Path.Combine(installPath, relative));
+            }
+
+            // The x86 wrapper is a native x64 process and therefore needs its own
+            // addon-enabled 64-bit ReShade proxy inside host64.
+            if (is32Bit)
+            {
+                progress?.Report("Creating the 64-bit host environment...");
+                const string hostReShade = "host64\\dxgi.dll";
+                deployed.Add(hostReShade);
+                DeployWithBackup(AuxInstallService.RsStagedPath64, Path.Combine(installPath, hostReShade));
+            }
+
+            var runtimeRoot = is32Bit ? Path.Combine(installPath, "host64") : installPath;
+
+            DeployRuntime(cachedSr, runtimeRoot, "nvngx_dlss.dll", deployed, installPath);
+            DeployRuntime(cachedFg, runtimeRoot, "nvngx_dlssg.dll", deployed, installPath);
+            DeployRuntime(cachedNr, runtimeRoot, "nvngx_dlssnr.dll", deployed, installPath);
+
+            var marker = new InstallMarker
+            {
+                Version = release.TagName,
+                Is32Bit = is32Bit,
+                Files = deployed.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            };
+            File.WriteAllText(Path.Combine(installPath, MarkerFileName),
+                JsonSerializer.Serialize(marker, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch
+        {
+            foreach (var relative in deployed.AsEnumerable().Reverse())
+                if (TryResolveUnderRoot(installPath, relative, out var target)) RestoreBackup(target);
+            throw;
+        }
+
+        CrashReporter.Log($"[Dlss5AioService] Installed {release.TagName} ({(is32Bit ? "x86 host" : "x64")}) to '{installPath}'");
+        progress?.Report($"DLSS5 AIO {release.TagName} installed");
+        return release.TagName;
+    }
+
+    public void Uninstall(string installPath)
+    {
+        var markerPath = Path.Combine(installPath, MarkerFileName);
+        if (!File.Exists(markerPath))
+        {
+            CrashReporter.Log($"[Dlss5AioService] No RHI deployment marker in '{installPath}'; leaving files untouched");
+            return;
+        }
+
+        try
+        {
+            var marker = JsonSerializer.Deserialize<InstallMarker>(File.ReadAllText(markerPath));
+            foreach (var relative in marker?.Files ?? Enumerable.Empty<string>())
+            {
+                if (!TryResolveUnderRoot(installPath, relative, out var target))
+                {
+                    CrashReporter.Log($"[Dlss5AioService] Ignored unsafe marker path '{relative}'");
+                    continue;
+                }
+                RestoreBackup(target);
+            }
+            File.Delete(markerPath);
+            RemoveEmptyOwnedDirectories(installPath);
+            CrashReporter.Log($"[Dlss5AioService] Removed RHI-managed AIO files from '{installPath}'");
+        }
+        catch (Exception ex)
+        {
+            CrashReporter.Log($"[Dlss5AioService] Uninstall failed for '{installPath}' — {ex.Message}");
+            throw;
+        }
+    }
+
+    internal static ReleaseAsset? SelectArchitectureAsset(IEnumerable<ReleaseAsset> assets, bool is32Bit)
+    {
+        var suffix = is32Bit ? "-32-bit.zip" : "-64-bit.zip";
+        return assets.FirstOrDefault(a =>
+            a.Name.StartsWith("DLSS5-ReShade-AIO-", StringComparison.OrdinalIgnoreCase) &&
+            a.Name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+    }
+
+    internal static bool TryResolveUnderRoot(string root, string relativePath, out string fullPath)
+    {
+        var normalizedRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        fullPath = Path.GetFullPath(Path.Combine(normalizedRoot, relativePath));
+        return fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<ReleaseInfo> GetLatestReleaseAsync()
+    {
+        var body = await _etagCache.GetWithETagAsync(_http, LatestReleaseApiUrl).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Could not query the latest DLSS5 AIO release from GitHub.");
+        using var json = JsonDocument.Parse(body);
+
+        var tag = json.RootElement.GetProperty("tag_name").GetString();
+        if (string.IsNullOrWhiteSpace(tag))
+            throw new InvalidOperationException("Latest DLSS5 AIO release has no tag name.");
+
+        var assets = new List<ReleaseAsset>();
+        foreach (var item in json.RootElement.GetProperty("assets").EnumerateArray())
+        {
+            var name = item.GetProperty("name").GetString();
+            var url = item.GetProperty("browser_download_url").GetString();
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(url))
+                assets.Add(new ReleaseAsset(name, url));
+        }
+        return new ReleaseInfo(tag, assets);
+    }
+
+    private async Task<string> EnsurePackageCachedAsync(
+        string version,
+        ReleaseAsset asset,
+        bool is32Bit,
+        IProgress<string>? progress)
+    {
+        var safeVersion = string.Concat(version.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c));
+        var destination = Path.Combine(CacheRoot, safeVersion, is32Bit ? "x86" : "x64");
+        if (PackageLooksComplete(destination, is32Bit)) return destination;
+
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        var tempDir = destination + ".tmp-" + Guid.NewGuid().ToString("N");
+        var tempZip = Path.Combine(Path.GetTempPath(), $"rhi-dlss5-aio-{Guid.NewGuid():N}.zip");
+        try
+        {
+            progress?.Report($"Downloading {asset.Name}...");
+            using (var response = await _http.GetAsync(asset.DownloadUrl, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+                await using var input = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                await using var output = File.Create(tempZip);
+                await input.CopyToAsync(output).ConfigureAwait(false);
+            }
+
+            Directory.CreateDirectory(tempDir);
+            using (var archive = ZipFile.OpenRead(tempZip))
+            {
+                foreach (var entry in archive.Entries)
+                {
+                    if (string.IsNullOrEmpty(entry.Name)) continue;
+                    if (!TryResolveUnderRoot(tempDir, entry.FullName, out var target))
+                        throw new InvalidDataException($"Unsafe path in DLSS5 AIO package: {entry.FullName}");
+                    Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+                    entry.ExtractToFile(target, overwrite: true);
+                }
+            }
+
+            ValidatePackage(tempDir, is32Bit);
+            if (Directory.Exists(destination)) Directory.Delete(destination, recursive: true);
+            Directory.Move(tempDir, destination);
+            return destination;
+        }
+        finally
+        {
+            try { if (File.Exists(tempZip)) File.Delete(tempZip); } catch { }
+            try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static bool PackageLooksComplete(string root, bool is32Bit)
+    {
+        try { ValidatePackage(root, is32Bit); return true; }
+        catch { return false; }
+    }
+
+    private static void ValidatePackage(string root, bool is32Bit)
+    {
+        var required = is32Bit
+            ? new[]
+            {
+                "standalone-dlssnr.addon32",
+                "dlss5-aio-x86.cfg",
+                "reshade-shaders\\Shaders\\DLSS5_Feed.fx",
+                "reshade-shaders\\Shaders\\DLSS5_Feed_impl.fxh",
+                "reshade-shaders\\Shaders\\DLSS5_Feed_D3D9.fx",
+                "host64\\AIO DLSS5 32-bit Wrapper.exe",
+                "host64\\standalone-dlssnr.addon64",
+                "host64\\nvngx.dll",
+                "host64\\reshade-shaders\\Shaders\\DLSS5_AIO_Feed.fx",
+            }
+            : new[]
+            {
+                "standalone-dlssnr.addon64",
+                "nvngx.dll",
+                "reshade-shaders\\Shaders\\DLSS5_AIO_Feed.fx",
+                "reshade-shaders\\Shaders\\StandaloneBoundary.fx",
+            };
+
+        var missing = required.Where(p => !File.Exists(Path.Combine(root, p))).ToArray();
+        if (missing.Length > 0)
+            throw new InvalidDataException("DLSS5 AIO package is incomplete. Missing: " + string.Join(", ", missing));
+    }
+
+    private static void DeployRuntime(
+        string? source,
+        string runtimeRoot,
+        string fileName,
+        List<string> deployed,
+        string installPath)
+    {
+        if (string.IsNullOrWhiteSpace(source) || !File.Exists(source))
+            throw new InvalidOperationException($"RHI could not download required runtime {fileName}.");
+        var target = Path.Combine(runtimeRoot, fileName);
+        deployed.Add(Path.GetRelativePath(installPath, target));
+        DeployWithBackup(source, target);
+    }
+
+    private static void ValidateRuntime(string? source, string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(source) || !File.Exists(source) || new FileInfo(source).Length == 0)
+            throw new InvalidOperationException($"RHI could not download required runtime {fileName}.");
+    }
+
+    private static void DeployWithBackup(string source, string target)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+        var backup = target + BackupSuffix;
+        if (!File.Exists(backup))
+        {
+            if (File.Exists(target)) File.Copy(target, backup);
+            else File.WriteAllBytes(backup, Array.Empty<byte>());
+        }
+        File.Copy(source, target, overwrite: true);
+    }
+
+    private static void RestoreBackup(string target)
+    {
+        var backup = target + BackupSuffix;
+        if (!File.Exists(backup)) return;
+        if (new FileInfo(backup).Length == 0)
+        {
+            if (File.Exists(target)) File.Delete(target);
+        }
+        else
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(backup, target, overwrite: true);
+        }
+        File.Delete(backup);
+    }
+
+    private static void RemoveEmptyOwnedDirectories(string installPath)
+    {
+        foreach (var relative in new[]
+        {
+            "host64\\reshade-shaders\\Shaders", "host64\\reshade-shaders", "host64",
+            "reshade-shaders\\Shaders", "reshade-shaders", "licenses",
+        })
+        {
+            var path = Path.Combine(installPath, relative);
+            try
+            {
+                if (Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any())
+                    Directory.Delete(path);
+            }
+            catch { }
+        }
+    }
+
+    internal sealed record ReleaseAsset(string Name, string DownloadUrl);
+    private sealed record ReleaseInfo(string TagName, List<ReleaseAsset> Assets);
+
+    private sealed class InstallMarker
+    {
+        public string Version { get; set; } = "";
+        public bool Is32Bit { get; set; }
+        public List<string> Files { get; set; } = new();
+    }
+}


### PR DESCRIPTION
## Summary

Adds [DLSS5 ReShade AIO](https://github.com/kibblerz/DLSS5-Reshade-AIO) as an opt-in method in RHI's Neural Rendering section.

- selects the matching 32-bit or 64-bit ZIP from the latest stable AIO release
- preserves the release's shader and host-wrapper directory layout
- deploys current DLSS SR, Frame Generation, and Neural Rendering runtimes through RHI's existing runtime service
- creates the complete `host64` environment automatically for 32-bit games, including 64-bit addon-enabled ReShade
- reports AIO/runtime/host status in the game detail panel
- safely backs up overwritten files and restores them when removing or switching methods
- validates required package files and rejects ZIP path traversal
- leaves RHI's existing automatic Neural Rendering method selection unchanged

A dedicated installer is used because the generic addon-pack ZIP path intentionally extracts only `.addon32`/`.addon64` files, while AIO also requires shaders and an architecture-specific wrapper layout.

## Validation

- `dotnet build RenoDXCommander.sln -c Debug -p:Platform=x64`
- `dotnet test RenoDXCommander.Tests/RenoDXCommander.Tests.csproj -c Release -p:Platform=x64`
- 38 tests passed, including new architecture-selection and package-path safety coverage