### PR TITLE
Fix support link and update test baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RHI detects your entire game library across every major store and handles ReShad
 
 ## Download
 
-**[Latest release](https://github.com/RankFTW/RenoDXChecker/releases/latest)** · **[Discord](https://discord.gg/yourserver)**
+**[Latest release](https://github.com/RankFTW/RenoDXChecker/releases/latest)** · **[Discord](https://discord.gg/ultraplace)**
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,7 @@ Items that improve maintainability, performance, or reliability. No user-facing 
 - Structural changes (add/remove rows) stay imperative
 
 ### Test Infrastructure
-- Fix test project build errors (interface stubs)
+- Baseline verification (`ea55a3d`, .NET SDK 9.0.315): `dotnet test RenoDXCommander.Tests/RenoDXCommander.Tests.csproj -p:Platform=x64` — 33 passed
 - Add integration tests: install/uninstall roundtrip, manifest parse → card assertions, settings save/load
 - CI pipeline: `dotnet build && dotnet test` on push
 


### PR DESCRIPTION
The README Discord link resolves to an unrelated server, and the roadmap still says the test project has broken interface stubs even though the suite builds successfully.

This replaces the support invite with the verified Ultra Place invite and records the current Windows x64 baseline: 33 tests passing at `ea55a3d` with .NET SDK 9.0.315. CI remains listed as future work.

Fixes #60
