### PR TITLE
Apply ReShade settings without a screenshot path

### DIFF
--- a/RenoDXCommander.Tests/CoreLogicTests.cs
+++ b/RenoDXCommander.Tests/CoreLogicTests.cs
@@ -427,4 +427,48 @@ public class CoreLogicTests
         Assert.Equal("1", ini["renodx"]["ForceBorderless"]);
         Assert.True(ini.ContainsKey("GENERAL"));
     }
+
+    [Fact]
+    public void ApplyScreenshotSettings_BlankPath_PreservesPathAndAppliesOtherSettings()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "[SCREENSHOT]\nSavePath=C:\\Existing\n[INPUT]\nKeyOverlay=36,0,0,0\nKeyScreenshot=44,0,0,0\n[OVERLAY]\nVariableListUseTabs=1\n");
+
+            SettingsHandler.ApplyScreenshotSettingsToIni(
+                tempFile, null, "45,1,0,0", "46,0,0,0", useTabs: false);
+
+            var ini = AuxInstallService.ParseIni(File.ReadAllLines(tempFile));
+            Assert.Equal(@"C:\Existing", ini["SCREENSHOT"]["SavePath"]);
+            Assert.Equal("45,1,0,0", ini["INPUT"]["KeyOverlay"]);
+            Assert.Equal("46,0,0,0", ini["INPUT"]["KeyScreenshot"]);
+            Assert.Equal("0", ini["OVERLAY"]["VariableListUseTabs"]);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ApplyScreenshotSettings_NonBlankPath_ReplacesPath()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "[SCREENSHOT]\nSavePath=C:\\Existing\n");
+
+            SettingsHandler.ApplyScreenshotSettingsToIni(
+                tempFile, @"D:\Screenshots", null, "44,0,0,0", useTabs: true);
+
+            var ini = AuxInstallService.ParseIni(File.ReadAllLines(tempFile));
+            Assert.Equal(@"D:\Screenshots", ini["SCREENSHOT"]["SavePath"]);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
 }

--- a/RenoDXCommander/SettingsHandler.cs
+++ b/RenoDXCommander/SettingsHandler.cs
@@ -473,11 +473,6 @@ public class SettingsHandler
 
         ViewModel.SaveSettingsPublic();
 
-        if (string.IsNullOrEmpty(screenshotPath))
-        {
-            return;
-        }
-
         // Iterate all game cards and apply screenshot path + hotkeys to eligible games
         int updatedCount = 0;
         foreach (var card in ViewModel.AllCards)
@@ -498,19 +493,16 @@ public class SettingsHandler
 
             try
             {
-                var savePath = perGame
-                    ? BuildSavePath(screenshotPath, card.GameName)
-                    : screenshotPath;
+                var savePath = string.IsNullOrEmpty(screenshotPath)
+                    ? null
+                    : perGame ? BuildSavePath(screenshotPath, card.GameName) : screenshotPath;
+                var overlayHotkey = AuxInstallService.IsRdr2(card.GameName)
+                    ? null
+                    : _currentHotkeyString;
 
                 foreach (var iniFile in iniFiles)
-                {
-                    AuxInstallService.ApplyScreenshotPath(iniFile, savePath);
-                    // Always apply hotkeys when user explicitly clicks Apply to All
-                    if (!AuxInstallService.IsRdr2(card.GameName))
-                        AuxInstallService.ApplyOverlayHotkey(iniFile, _currentHotkeyString);
-                    AuxInstallService.ApplyScreenshotHotkey(iniFile, _currentScreenshotHotkeyString);
-                    AuxInstallService.ApplyVariableListUseTabs(iniFile, ViewModel.Settings.RsVariableListUseTabs);
-                }
+                    ApplyScreenshotSettingsToIni(iniFile, savePath, overlayHotkey,
+                        _currentScreenshotHotkeyString, ViewModel.Settings.RsVariableListUseTabs);
                 updatedCount++;
             }
             catch (Exception ex)
@@ -520,15 +512,33 @@ public class SettingsHandler
         }
 
         // Show confirmation dialog
+        var appliedSettings = string.IsNullOrEmpty(screenshotPath)
+            ? "ReShade hotkeys and effect list style"
+            : "Screenshot path, ReShade hotkeys, and effect list style";
         var dialog = new ContentDialog
         {
             Title = "Screenshots & Hotkeys",
-            Content = $"Screenshot path, ReShade hotkeys, and effect list style applied to {updatedCount} reshade.ini file{(updatedCount == 1 ? "" : "s")}.",
+            Content = $"{appliedSettings} applied to {updatedCount} game{(updatedCount == 1 ? "" : "s")}.",
             CloseButtonText = "OK",
             XamlRoot = _window.Content.XamlRoot,
             RequestedTheme = ElementTheme.Dark,
         };
         await DialogService.ShowSafeAsync(dialog);
+    }
+
+    internal static void ApplyScreenshotSettingsToIni(
+        string iniFilePath,
+        string? savePath,
+        string? overlayHotkey,
+        string screenshotHotkey,
+        bool useTabs)
+    {
+        if (!string.IsNullOrWhiteSpace(savePath))
+            AuxInstallService.ApplyScreenshotPath(iniFilePath, savePath);
+        if (overlayHotkey != null)
+            AuxInstallService.ApplyOverlayHotkey(iniFilePath, overlayHotkey);
+        AuxInstallService.ApplyScreenshotHotkey(iniFilePath, screenshotHotkey);
+        AuxInstallService.ApplyVariableListUseTabs(iniFilePath, useTabs);
     }
 
     /// <summary>


### PR DESCRIPTION
When the screenshot folder is blank, the settings handler returns before applying ReShade hotkeys or the effect-list style. Since blank is the default, "Apply to All Games" can silently do nothing.

This treats a blank folder as "preserve each game's current screenshot path" while applying the other settings. Existing per-game locks and the RDR2/Max Payne 3 overlay-key exception remain intact. The confirmation now reports updated games rather than INI files.

Validation: `dotnet test RenoDXCommander.Tests/RenoDXCommander.Tests.csproj -p:Platform=x64` (35 passed).
