### PR TITLE
Allow clearing ReShade screenshot hotkeys

### DIFF
--- a/RenoDXCommander.Tests/CoreLogicTests.cs
+++ b/RenoDXCommander.Tests/CoreLogicTests.cs
@@ -427,4 +427,36 @@ public class CoreLogicTests
         Assert.Equal("1", ini["renodx"]["ForceBorderless"]);
         Assert.True(ini.ContainsKey("GENERAL"));
     }
+
+    [Fact]
+    public void ScreenshotHotkey_BackspaceClearsAndNormalKeysRemainUnchanged()
+    {
+        Assert.Equal("0,0,0,0", HotkeyManager.BuildScreenshotHotkeyString(8, true, true, true));
+        Assert.Equal("None", HotkeyManager.FormatHotkeyDisplay("0,0,0,0"));
+        Assert.Equal("75,1,1,0", HotkeyManager.BuildScreenshotHotkeyString(75, true, true, false));
+        Assert.Equal("44,0,0,0", HotkeyManager.BuildScreenshotHotkeyString(44, false, false, false));
+    }
+
+    [Fact]
+    public void DisabledScreenshotHotkey_RoundTripsThroughIniAndSettingsDictionary()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            AuxInstallService.ApplyScreenshotHotkey(tempFile, "0,0,0,0");
+            var ini = AuxInstallService.ParseIni(File.ReadAllLines(tempFile));
+            Assert.Equal("0,0,0,0", ini["INPUT"]["KeyScreenshot"]);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+
+        var saved = new Dictionary<string, string>();
+        var settings = new SettingsViewModel { ScreenshotHotkey = "0,0,0,0" };
+        settings.SaveSettingsToDict(saved);
+        var restored = new SettingsViewModel();
+        restored.LoadSettingsFromDict(saved);
+        Assert.Equal("0,0,0,0", restored.ScreenshotHotkey);
+    }
 }

--- a/RenoDXCommander/HotkeyManager.cs
+++ b/RenoDXCommander/HotkeyManager.cs
@@ -60,12 +60,20 @@ public static class HotkeyManager
         return $"{vk},{(ctrl ? 1 : 0)},{(shift ? 1 : 0)},{(alt ? 1 : 0)}";
     }
 
+    /// <summary>Builds a ReShade screenshot shortcut, using Backspace to clear it.</summary>
+    public static string BuildScreenshotHotkeyString(int vk, bool shift, bool ctrl, bool alt)
+    {
+        return vk == 8 ? "0,0,0,0" : BuildHotkeyString(vk, shift, ctrl, alt);
+    }
+
     /// <summary>
     /// Formats a hotkey into a human-readable display string.
     /// Modifier order: Ctrl, Shift, Alt, then the main key name.
     /// </summary>
     public static string FormatHotkeyDisplay(int vk, bool shift, bool ctrl, bool alt)
     {
+        if (vk == 0) return "None";
+
         var parts = new List<string>();
         if (ctrl) parts.Add("Ctrl");
         if (shift) parts.Add("Shift");

--- a/RenoDXCommander/MainWindow.Events.Components.cs
+++ b/RenoDXCommander/MainWindow.Events.Components.cs
@@ -245,7 +245,7 @@ public sealed partial class MainWindow
             FontSize = 12,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
-        ToolTipService.SetToolTip(screenshotHotkeyBox, "Click here then press your desired key. Written to all reshade*.ini files for this game.");
+        ToolTipService.SetToolTip(screenshotHotkeyBox, "Press a key to assign it, or Backspace to clear it. Written to all reshade*.ini files for this game.");
         screenshotHotkeyBox.GotFocus  += (s, ev) => screenshotHotkeyBox.Text = "Press a key...";
         screenshotHotkeyBox.KeyDown   += (s, ev) =>
         {
@@ -254,7 +254,7 @@ public sealed partial class MainWindow
             bool shift2 = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Shift).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
             bool ctrl2  = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Control).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
             bool alt2   = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Menu).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
-            screenshotHotkeyString = HotkeyManager.BuildHotkeyString(vk2, shift2, ctrl2, alt2);
+            screenshotHotkeyString = HotkeyManager.BuildScreenshotHotkeyString(vk2, shift2, ctrl2, alt2);
             screenshotHotkeyBox.Text = HotkeyManager.FormatHotkeyDisplay(screenshotHotkeyString);
             ev.Handled = true;
         };

--- a/RenoDXCommander/MainWindow.xaml
+++ b/RenoDXCommander/MainWindow.xaml
@@ -1396,6 +1396,7 @@
                                                  Background="{StaticResource SurfaceInputBrush}"
                                                  Foreground="{StaticResource TextSecondaryBrush}"
                                                  BorderBrush="{StaticResource BorderSubtleBrush}"
+                                                 ToolTipService.ToolTip="Press a key to assign it, or Backspace to clear it."
                                                  PreviewKeyDown="ScreenshotHotkeyBox_PreviewKeyDown"/>
                                         <Button Grid.Column="1" Content="↺" Click="ResetScreenshotHotkey_Click"
                                                 ToolTipService.ToolTip="Reset to Print Screen"

--- a/RenoDXCommander/SettingsHandler.cs
+++ b/RenoDXCommander/SettingsHandler.cs
@@ -1195,11 +1195,11 @@ public class SettingsHandler
             .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Menu)
             .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
 
-        _currentScreenshotHotkeyString = HotkeyManager.BuildHotkeyString(vk, shift, ctrl, alt);
+        _currentScreenshotHotkeyString = HotkeyManager.BuildScreenshotHotkeyString(vk, shift, ctrl, alt);
 
         if (sender is TextBox hotkeyBox)
         {
-            hotkeyBox.Text = HotkeyManager.FormatHotkeyDisplay(vk, shift, ctrl, alt);
+            hotkeyBox.Text = HotkeyManager.FormatHotkeyDisplay(_currentScreenshotHotkeyString);
         }
 
         e.Handled = true;


### PR DESCRIPTION
RHI currently records Backspace as the screenshot shortcut, while ReShade uses Backspace to clear a shortcut.

This maps Backspace to ReShade's disabled value (`0,0,0,0`) in both the global settings control and the per-game ReShade panel. Disabled shortcuts display as "None" and persist through the existing INI and settings formats. Reset still restores Print Screen.

Validation: `dotnet test RenoDXCommander.Tests/RenoDXCommander.Tests.csproj -p:Platform=x64` (35 passed).

Fixes #75
